### PR TITLE
Migrate homepage to next-intl useTranslations() (i18n canonical)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,6 +2,8 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { notFound } from "next/navigation"
+import { NextIntlClientProvider } from "next-intl"
+import { getTranslations, getMessages, unstable_setRequestLocale } from "next-intl/server"
 import { locales } from "@/i18n"
 import "../globals.css"
 
@@ -38,6 +40,11 @@ export default async function LocaleLayout({
     notFound()
   }
 
+  unstable_setRequestLocale(locale)
+
+  const t = await getTranslations({ locale, namespace: "layout" })
+  const messages = await getMessages()
+
   return (
     <html lang={locale} className={inter.variable}>
       <head>
@@ -45,9 +52,11 @@ export default async function LocaleLayout({
       </head>
       <body className="antialiased font-sans">
         <a href="#main-content" className="skip-link">
-          {locale === "es" ? "Ir al contenido principal" : "Skip to main content"}
+          {t("skipToContent")}
         </a>
-        {children}
+        <NextIntlClientProvider messages={messages}>
+          {children}
+        </NextIntlClientProvider>
       </body>
     </html>
   )

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useEffect, useRef, useState, useCallback } from "react"
+import { useEffect, useRef, useState, useCallback, useMemo } from "react"
 import { useParams, useRouter } from "next/navigation"
+import { useTranslations } from "next-intl"
 
 const LANGUAGE_COOKIE = "preferred-language"
 
@@ -73,7 +74,7 @@ export default function PortfolioPage() {
   const params = useParams()
   const router = useRouter()
   const locale = (((params?.locale as string) || "en") === "es" ? "es" : "en") as Lang
-  const isSpanish = locale === "es"
+  const t = useTranslations("home")
 
   const [theme, setTheme] = useState<Theme>("light")
   const [hydrated, setHydrated] = useState(false)
@@ -105,7 +106,7 @@ export default function PortfolioPage() {
   const toggleTheme = () => setTheme((t) => (t === "dark" ? "light" : "dark"))
 
   const switchLocale = () => {
-    const target: Lang = isSpanish ? "en" : "es"
+    const target: Lang = locale === "es" ? "en" : "es"
     const expires = new Date()
     expires.setFullYear(expires.getFullYear() + 1)
     document.cookie = `${LANGUAGE_COOKIE}=${target}; expires=${expires.toUTCString()}; path=/`
@@ -131,50 +132,31 @@ export default function PortfolioPage() {
   }, [])
 
   // Build CASES per language
-  const CASES: Record<CaseKey, CaseData> = {
+  const CASES: Record<CaseKey, CaseData> = useMemo(() => ({
     fingo: {
       num: "01",
-      kicker: isSpanish ? "iOS · 2025" : "iOS · 2025",
+      kicker: "iOS · 2025",
       title: {
         pre: "Fingo — ",
-        it: isSpanish ? "decisiones en grupo, fácil." : "group choice, made easy.",
+        it: t("cases.fingo.titleIt"),
       },
-      desc: isSpanish ? (
-        <>
-          Una app de iOS para decidir en grupo al instante — ruletas, monedas, flechas giratorias,
-          toque-para-elegir. Totalmente personalizable, con <em>háptics</em> que hacen que cada
-          elección se sienta intencional. Construida con SwiftUI.
-        </>
-      ) : (
-        <>
-          An iOS app for making group decisions instantly — wheels, coins, spinning arrows,
-          tap-to-choose. Fully customizable, with <em>haptics</em> that make each pick feel
-          deliberate. Built with SwiftUI.
-        </>
-      ),
-      meta: isSpanish
-        ? [
-            ["Plataforma", "iOS 16+"],
-            ["Stack", "SwiftUI · Swift · Core Haptics"],
-            ["Estado", "Disponible en App Store"],
-            ["Año", "2025"],
-          ]
-        : [
-            ["Platform", "iOS 16+"],
-            ["Stack", "SwiftUI · Swift · Core Haptics"],
-            ["Status", "Live on the App Store"],
-            ["Year", "2025"],
-          ],
+      desc: t.rich("cases.fingo.descRich", { it: (chunks) => <em>{chunks}</em> }),
+      meta: [
+        [t("cases.meta.platform"), "iOS 16+"],
+        [t("cases.meta.stack"), "SwiftUI · Swift · Core Haptics"],
+        [t("cases.meta.status"), t("cases.fingo.metaStatus")],
+        [t("cases.meta.year"), "2025"],
+      ],
       actions: [
         {
-          label: isSpanish ? "Ver en App Store" : "View on App Store",
+          label: t("cases.fingo.actionPrimary"),
           href: "https://apps.apple.com/mx/app/fingo-group-choice-made-easy/id6747301883",
           kind: "primary",
           ext: true,
           icon: "external",
         },
         {
-          label: isSpanish ? "Soporte" : "Support",
+          label: t("cases.fingo.actionGhost"),
           href: `/${locale}/fingo/support`,
           kind: "ghost",
           icon: "help",
@@ -184,46 +166,27 @@ export default function PortfolioPage() {
     },
     savely: {
       num: "02",
-      kicker: isSpanish ? "iOS · Fintech · 2026" : "iOS · Fintech · 2026",
+      kicker: "iOS · Fintech · 2026",
       title: {
         pre: "Savely — ",
-        it: isSpanish ? "finanzas personales, en calma." : "personal finance, quietly.",
+        it: t("cases.savely.titleIt"),
       },
-      desc: isSpanish ? (
-        <>
-          Un asistente financiero tranquilo. Rastrea gastos, ahorra con metas, recibe alertas
-          inteligentes antes de que las cosas se salgan. Seguridad bancaria, interfaz{" "}
-          <em>silenciosa</em>. Construida con SwiftUI y APIs bancarias seguras.
-        </>
-      ) : (
-        <>
-          A calm financial assistant. Track spending, save with goals, get smart alerts before
-          things slip. Bank-grade security, <em>quiet</em> interface. Built with SwiftUI and secure
-          banking APIs.
-        </>
-      ),
-      meta: isSpanish
-        ? [
-            ["Plataforma", "iOS 16+"],
-            ["Stack", "SwiftUI · Swift · APIs bancarias"],
-            ["Estado", "En revisión · Próximamente"],
-            ["Año", "2026"],
-          ]
-        : [
-            ["Platform", "iOS 16+"],
-            ["Stack", "SwiftUI · Swift · Banking APIs"],
-            ["Status", "In review · App Store soon"],
-            ["Year", "2026"],
-          ],
+      desc: t.rich("cases.savely.descRich", { it: (chunks) => <em>{chunks}</em> }),
+      meta: [
+        [t("cases.meta.platform"), "iOS 16+"],
+        [t("cases.meta.stack"), "SwiftUI · Swift · Banking APIs"],
+        [t("cases.meta.status"), t("cases.savely.metaStatus")],
+        [t("cases.meta.year"), "2026"],
+      ],
       actions: [
         {
-          label: isSpanish ? "Próximamente" : "Coming soon",
+          label: t("cases.savely.actionPrimary"),
           href: "#",
           kind: "primary disabled",
           icon: "clock",
         },
         {
-          label: isSpanish ? "Soporte" : "Support",
+          label: t("cases.savely.actionGhost"),
           href: `/${locale}/savely/support`,
           kind: "ghost",
           icon: "help",
@@ -233,40 +196,21 @@ export default function PortfolioPage() {
     },
     mezcal: {
       num: "03",
-      kicker: isSpanish ? "Web · E-commerce · 2025" : "Web · E-commerce · 2025",
+      kicker: "Web · E-commerce · 2025",
       title: {
         pre: "Mi Mezcal — ",
         it: "Destilería Lorenzana.",
       },
-      desc: isSpanish ? (
-        <>
-          Tienda e historia para una marca de mezcal artesanal de Oaxaca. Un sitio editorial y
-          tranquilo construido para vender — variedades, origen, pedidos directos.{" "}
-          <em>Hecho a mano</em> de la marca al checkout.
-        </>
-      ) : (
-        <>
-          Storefront and story for an artisanal mezcal brand out of Oaxaca. A quiet, editorial site
-          built to sell — varieties, origin, direct orders. <em>Hand-built</em> from brand to
-          checkout.
-        </>
-      ),
-      meta: isSpanish
-        ? [
-            ["Plataforma", "Web · Responsiva"],
-            ["Stack", "Next.js · TypeScript · Stripe"],
-            ["Estado", "En vivo"],
-            ["Año", "2025"],
-          ]
-        : [
-            ["Platform", "Web · Responsive"],
-            ["Stack", "Next.js · TypeScript · Stripe"],
-            ["Status", "Live"],
-            ["Year", "2025"],
-          ],
+      desc: t.rich("cases.mezcal.descRich", { it: (chunks) => <em>{chunks}</em> }),
+      meta: [
+        [t("cases.meta.platform"), t("cases.mezcal.metaPlatform")],
+        [t("cases.meta.stack"), "Next.js · TypeScript · Stripe"],
+        [t("cases.meta.status"), t("cases.mezcal.metaStatus")],
+        [t("cases.meta.year"), "2025"],
+      ],
       actions: [
         {
-          label: isSpanish ? "Visitar sitio" : "Visit site",
+          label: t("cases.mezcal.actionPrimary"),
           href: "https://www.destilerialorenzana.com/",
           kind: "primary",
           ext: true,
@@ -275,7 +219,7 @@ export default function PortfolioPage() {
       ],
       preview: "mezcal",
     },
-  }
+  }), [t, locale])
 
   const openCase = useCallback((key: CaseKey, trigger?: HTMLElement) => {
     lastFocusRef.current = trigger ?? (document.activeElement as HTMLElement | null)
@@ -325,19 +269,19 @@ export default function PortfolioPage() {
           <nav aria-label="Primary">
             <ul className="ab-nav-links">
               <li>
-                <a href="#top">{isSpanish ? "Inicio" : "Home"}</a>
+                <a href="#top">{t("nav.home")}</a>
               </li>
               <li>
-                <a href="#work">{isSpanish ? "Proyectos" : "Work"}</a>
+                <a href="#work">{t("nav.work")}</a>
               </li>
               <li>
                 <a href="#stack">Stack</a>
               </li>
               <li>
-                <a href="#studio">{isSpanish ? "Sobre mí" : "About"}</a>
+                <a href="#studio">{t("nav.about")}</a>
               </li>
               <li>
-                <a href="#contact">{isSpanish ? "Contacto" : "Contact"}</a>
+                <a href="#contact">{t("nav.contact")}</a>
               </li>
             </ul>
           </nav>
@@ -346,16 +290,16 @@ export default function PortfolioPage() {
             <button
               className="ab-chip ab-chip-lang"
               onClick={switchLocale}
-              aria-label={isSpanish ? "Switch to English" : "Cambiar a Español"}
+              aria-label={t("locale.switchAria")}
             >
-              <b>{isSpanish ? "ES" : "EN"}</b>
+              <b>{locale === "es" ? "ES" : "EN"}</b>
               <span className="ab-sep" />
-              <span className="off">{isSpanish ? "EN" : "ES"}</span>
+              <span className="off">{locale === "es" ? "EN" : "ES"}</span>
             </button>
             <button
               className="ab-theme-toggle"
               onClick={toggleTheme}
-              aria-label={isSpanish ? "Cambiar tema" : "Toggle theme"}
+              aria-label={t("theme.toggleAria")}
             >
               <svg className="sun" viewBox="0 0 24 24" aria-hidden="true">
                 <circle cx="12" cy="12" r="4" />
@@ -379,41 +323,16 @@ export default function PortfolioPage() {
               <div className="ab-reveal">
                 <div className="ab-eyebrow-row">
                   <span className="num-xs">01</span>
-                  <span className="ab-smallcaps">
-                    {isSpanish ? "Software · Oficio digital" : "Software · Digital craft"}
-                  </span>
+                  <span className="ab-smallcaps">{t("hero.eyebrow")}</span>
                 </div>
                 <h1 id="hero-heading" className="ab-h-title ab-serif">
-                  {isSpanish ? (
-                    <>
-                      <span>Apps hechas</span>
-                      <br />
-                      <span>con </span>
-                      <span className="ab-it">intención.</span>
-                    </>
-                  ) : (
-                    <>
-                      <span>Apps crafted</span>
-                      <br />
-                      <span>with </span>
-                      <span className="ab-it">intention.</span>
-                    </>
-                  )}
+                  <span>{t("hero.titleLine1")}</span>
+                  <br />
+                  <span>{t("hero.titleLine2")}</span>
+                  <span className="ab-it">{t("hero.titleIt")}</span>
                 </h1>
                 <p className="ab-h-sub">
-                  {isSpanish ? (
-                    <>
-                      Un pequeño <em>atelier</em> de software desde Tijuana. Forma minimalista, y
-                      la paciencia de terminar las cosas. Diseño y construyo apps de iOS y la web
-                      que las acompaña.
-                    </>
-                  ) : (
-                    <>
-                      A small <em>atelier</em> for software out of Tijuana. Minimalist form, and
-                      the patience to finish things. I design and build iOS apps and the web
-                      around them.
-                    </>
-                  )}
+                  {t.rich("hero.subtitle", { it: (chunks) => <em>{chunks}</em> })}
                 </p>
               </div>
 
@@ -424,27 +343,25 @@ export default function PortfolioPage() {
               >
                 <div className="ab-colophon">
                   <div className="row">
-                    <span className="k">{isSpanish ? "Ubicación" : "Location"}</span>
+                    <span className="k">{t("colophon.locationLabel")}</span>
                     <span className="v">Tijuana · BC</span>
                   </div>
                   <hr className="ab-hair" />
                   <div className="row">
-                    <span className="k">{isSpanish ? "Estado" : "Status"}</span>
+                    <span className="k">{t("colophon.statusLabel")}</span>
                     <span className="v avail">
                       <span className="ab-dot" aria-hidden="true" />{" "}
-                      <em>
-                        {isSpanish ? "Disponible para encargos" : "Available for commissions"}
-                      </em>
+                      <em>{t("colophon.status")}</em>
                     </span>
                   </div>
                   <hr className="ab-hair" />
                   <div className="row">
                     <span className="k">Est.</span>
-                    <span className="v">2023 — {isSpanish ? "En curso" : "Ongoing"}</span>
+                    <span className="v">2023 — {t("colophon.ongoing")}</span>
                   </div>
                   <hr className="ab-hair" />
                   <div className="row">
-                    <span className="k">{isSpanish ? "Firmado" : "Signed"}</span>
+                    <span className="k">{t("colophon.signed")}</span>
                     <span className="v ab-sig">— Ivan Lorenzana</span>
                   </div>
                 </div>
@@ -457,15 +374,13 @@ export default function PortfolioPage() {
             <div className="ab-wrap-full" style={{ maxWidth: 1480, margin: "0 auto" }}>
               <div className="ab-vitrine-cap">
                 <div>
-                  <span className="eye">{isSpanish ? "Vitrina — 2025" : "Showcase — 2025"}</span>
+                  <span className="eye">{t("vitrine.eyebrow")}</span>
                   <h2>
-                    <span>{isSpanish ? "Tres piezas " : "Three recent "}</span>
-                    <em>{isSpanish ? "recientes." : "pieces."}</em>
+                    <span>{t("vitrine.titlePre")}</span>
+                    <em>{t("vitrine.titleIt")}</em>
                   </h2>
                 </div>
-                <span className="m">
-                  {isSpanish ? "— Pasa el cursor para enfocar" : "— Hover to focus"}
-                </span>
+                <span className="m">{t("vitrine.hint")}</span>
               </div>
 
               <div className="ab-phones">
@@ -559,16 +474,14 @@ export default function PortfolioPage() {
               <div>
                 <div className="s-eye">
                   <span className="num-xs">02</span>
-                  <span className="ab-smallcaps">{isSpanish ? "La obra" : "The work"}</span>
+                  <span className="ab-smallcaps">{t("work.eyebrow")}</span>
                 </div>
                 <h2 id="work-title" className="s-title">
-                  <span>{isSpanish ? "Obra " : "Selected "}</span>
-                  <span className="ab-it">{isSpanish ? "selecta." : "work."}</span>
+                  <span>{t("work.titlePre")}</span>
+                  <span className="ab-it">{t("work.titleIt")}</span>
                 </h2>
               </div>
-              <div className="s-meta">
-                {isSpanish ? "Índice — 2023 / 2026" : "Index — 2023 / 2026"}
-              </div>
+              <div className="s-meta">{t("work.indexMeta")}</div>
             </div>
 
             <div className="ab-index-list" role="list">
@@ -576,22 +489,16 @@ export default function PortfolioPage() {
                 const c = CASES[key]
                 const name =
                   key === "fingo"
-                    ? { pre: "Fingo", it: isSpanish ? " — decisiones en grupo, fácil." : " — group choice, made easy." }
+                    ? { pre: "Fingo", it: ` — ${t("cases.fingo.titleIt")}` }
                     : key === "savely"
-                      ? { pre: "Savely", it: isSpanish ? " — finanzas personales, en calma." : " — personal finance, quietly." }
+                      ? { pre: "Savely", it: ` — ${t("cases.savely.titleIt")}` }
                       : { pre: "Mi Mezcal", it: " — Destilería Lorenzana." }
                 const tag =
                   key === "fingo"
-                    ? isSpanish
-                      ? "Ruletas, monedas, háptics — decisiones de un toque."
-                      : "Wheels, coins, haptics — decisions in a tap."
+                    ? t("cases.fingo.tag")
                     : key === "savely"
-                      ? isSpanish
-                        ? "Balance, presupuesto, alertas — un asistente financiero tranquilo."
-                        : "Balance, budgets, alerts — a calm financial assistant."
-                      : isSpanish
-                        ? "Una marca de mezcal artesanal — tienda e historia."
-                        : "An artisanal mezcal brand — storefront and story."
+                      ? t("cases.savely.tag")
+                      : t("cases.mezcal.tag")
                 const stack =
                   key === "fingo"
                     ? ["iOS", "SwiftUI", "Haptics"]
@@ -625,7 +532,7 @@ export default function PortfolioPage() {
                         <span key={s}>{s}</span>
                       ))}
                     </div>
-                    <div className="p-plat">{isSpanish ? "Ver proyecto" : "View case"}</div>
+                    <div className="p-plat">{t("work.viewCase")}</div>
                     <div className="arr">→</div>
                   </button>
                 )
@@ -641,28 +548,14 @@ export default function PortfolioPage() {
               <div>
                 <div className="s-eye ab-wb-eye">
                   <span className="num-xs">03</span>
-                  <span className="ab-smallcaps">
-                    {isSpanish ? "El taller" : "The workbench"}
-                  </span>
+                  <span className="ab-smallcaps">{t("workbench.eyebrow")}</span>
                 </div>
                 <h2 id="wb-title" className="ab-wb-title">
-                  <span>{isSpanish ? "Herramientas del " : "Tools of the "}</span>
-                  <span className="ab-it">{isSpanish ? "oficio." : "trade."}</span>
+                  <span>{t("workbench.titlePre")}</span>
+                  <span className="ab-it">{t("workbench.titleIt")}</span>
                 </h2>
                 <p className="ab-wb-desc">
-                  {isSpanish ? (
-                    <>
-                      Un conjunto pequeño y opinado. Swift y SwiftUI para el teléfono;{" "}
-                      <em>Next.js</em> y TypeScript para la web; Postgres para lo que debe durar.
-                      Figma, Xcode, Claude Code — el banco se mantiene limpio.
-                    </>
-                  ) : (
-                    <>
-                      A small, opinionated set. Swift and SwiftUI for the phone; <em>Next.js</em>{" "}
-                      and TypeScript for the web; Postgres for things that must last. Figma, Xcode,
-                      Claude Code — the bench stays tidy.
-                    </>
-                  )}
+                  {t.rich("workbench.desc", { it: (chunks) => <em>{chunks}</em> })}
                 </p>
                 <a
                   href="https://github.com/Ivan-LB"
@@ -681,7 +574,7 @@ export default function PortfolioPage() {
               <div className="ab-wb-groups">
                 <div className="ab-wb-group">
                   <h4>
-                    {isSpanish ? "Frontend & Móvil" : "Frontend & Mobile"}{" "}
+                    {t("workbench.groups.frontend")}{" "}
                     <span className="gn">i.</span>
                   </h4>
                   <div className="ab-pills">
@@ -697,7 +590,7 @@ export default function PortfolioPage() {
                 </div>
                 <div className="ab-wb-group">
                   <h4>
-                    {isSpanish ? "Backend & Infra" : "Backend & Infra"}{" "}
+                    {t("workbench.groups.backend")}{" "}
                     <span className="gn">ii.</span>
                   </h4>
                   <div className="ab-pills">
@@ -711,7 +604,7 @@ export default function PortfolioPage() {
                 </div>
                 <div className="ab-wb-group">
                   <h4>
-                    {isSpanish ? "Oficio" : "Craft"} <span className="gn">iii.</span>
+                    {t("workbench.groups.craft")} <span className="gn">iii.</span>
                   </h4>
                   <div className="ab-pills">
                     {["Figma", "Xcode", "Claude Code", "Git"].map((p, i) => (
@@ -731,23 +624,23 @@ export default function PortfolioPage() {
         <section id="studio" className="ab-cta" aria-labelledby="cta-title">
           <div className="ab-wrap">
             <div className="eye ab-smallcaps">
-              — <em>{isSpanish ? "Encargos abiertos" : "Commissions open"}</em> —
+              — <em>{t("cta.eyebrow")}</em> —
             </div>
             <h2 id="cta-title">
-              <span>{isSpanish ? "Hagamos algo " : "Let's build something "}</span>
-              <span className="ab-it">{isSpanish ? "bien hecho." : "well-made."}</span>
+              <span>{t("cta.titlePre")}</span>
+              <span className="ab-it">{t("cta.titleIt")}</span>
             </h2>
 
             <div className="ab-cta-actions" id="contact">
               <a className="ab-btn-mail" href="mailto:ivanlorenzana@outlook.com">
-                <span className="lbl">{isSpanish ? "Escribe a" : "Write to"}</span>
+                <span className="lbl">{t("cta.writeTo")}</span>
                 <span className="mail">ivanlorenzana@outlook.com</span>
               </a>
               <span />
               <div className="ab-cta-links">
                 <span className="s">Atelier Belli</span>
                 <span>
-                  Tijuana ⇄ <span>{isSpanish ? "Todo el mundo" : "Worldwide"}</span>
+                  Tijuana ⇄ <span>{t("cta.worldwide")}</span>
                 </span>
                 <span>
                   <a href="https://github.com/Ivan-LB" target="_blank" rel="noopener noreferrer">
@@ -781,9 +674,9 @@ export default function PortfolioPage() {
               </div>
               <div className="mid">Atelier Belli</div>
               <div className="right">
-                <a href={`/${locale}/privacy`}>{isSpanish ? "Privacidad" : "Privacy"}</a>
+                <a href={`/${locale}/privacy`}>{t("footer.privacy")}</a>
                 &nbsp;·&nbsp;
-                <a href={`/${locale}/terms`}>{isSpanish ? "Términos" : "Terms"}</a>
+                <a href={`/${locale}/terms`}>{t("footer.terms")}</a>
               </div>
             </footer>
           </div>
@@ -812,7 +705,7 @@ export default function PortfolioPage() {
             ref={closeBtnRef}
             className="ab-case-close"
             onClick={closeCase}
-            aria-label={isSpanish ? "Cerrar" : "Close"}
+            aria-label={t("modal.close")}
           >
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M6 6l12 12M18 6l-12 12" />

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,67 +1,107 @@
 {
-    "navigation": {
+  "notFound": {
+    "title": "Page Not Found",
+    "description": "Sorry, the page you're looking for doesn't exist or has been moved.",
+    "backHome": "Back to Home"
+  },
+  "layout": {
+    "skipToContent": "Skip to main content"
+  },
+  "home": {
+    "nav": {
       "home": "Home",
-      "about": "About me",
-      "apps": "Apps",
-      "privacy": "Privacy",
+      "work": "Work",
+      "about": "About",
       "contact": "Contact"
     },
+    "locale": {
+      "switchAria": "Cambiar a Español"
+    },
+    "theme": {
+      "toggleAria": "Toggle theme"
+    },
     "hero": {
-      "title": "Atelier Belli",
-      "subtitle": "Software development and digital solutions",
-      "cta": "View my work"
+      "eyebrow": "Software · Digital craft",
+      "titleLine1": "Apps crafted",
+      "titleLine2": "with ",
+      "titleIt": "intention.",
+      "subtitle": "A small <it>atelier</it> for software out of Tijuana. Minimalist form, and the patience to finish things. I design and build iOS apps and the web around them."
     },
-    "about": {
-      "title": "About me",
-      "description": "I'm a full-stack developer passionate about creating clean and efficient digital experiences. With one foot in technical precision and another in the elegance of minimalist design, I seek harmony in every line of code. My Franco-Italian approach is reflected in robust solutions with a distinctive touch of style. Welcome to my digital atelier!"
+    "colophon": {
+      "locationLabel": "Location",
+      "statusLabel": "Status",
+      "status": "Available for commissions",
+      "ongoing": "Ongoing",
+      "signed": "Signed"
     },
-    "apps": {
-      "title": "My Applications",
-      "fingo": {
-        "title": "Fingo",
-        "description": "Fingo is the ultimate app for making group decisions instantly: choose with taps, wheels, spinning arrows, or coin flips. Fully customizable, with haptics that make every choice quick, fun, and fair."
-      },
-      "savely": {
-        "title": "Savely",
-        "description": "Savely is your personal finance assistant: control your expenses, save with personalized goals, and receive smart alerts to keep your budget in order. Intuitive design and guaranteed banking security."
-      },
-      "mezcal": {
-        "title": "Mi Mezcal",
-        "description": "Discover Mi Mezcal, the website for my artisanal mezcal brand: learn our story, explore varieties, and place your order directly. Elegant design and authentic user experience."
-      },
-      "buttons": {
-        "support": "Support",
-        "appStore": "View on App Store",
-        "visitSite": "Visit site"
+    "vitrine": {
+      "eyebrow": "Showcase — 2025",
+      "titlePre": "Three recent ",
+      "titleIt": "pieces.",
+      "hint": "— Hover to focus"
+    },
+    "work": {
+      "eyebrow": "The work",
+      "titlePre": "Selected ",
+      "titleIt": "work.",
+      "indexMeta": "Index — 2023 / 2026",
+      "viewCase": "View case"
+    },
+    "workbench": {
+      "eyebrow": "The workbench",
+      "titlePre": "Tools of the ",
+      "titleIt": "trade.",
+      "desc": "A small, opinionated set. Swift and SwiftUI for the phone; <it>Next.js</it> and TypeScript for the web; Postgres for things that must last. Figma, Xcode, Claude Code — the bench stays tidy.",
+      "groups": {
+        "frontend": "Frontend & Mobile",
+        "backend": "Backend & Infra",
+        "craft": "Craft"
       }
     },
-    "privacy": {
-      "title": "Your Privacy is Important",
-      "description": "At Atelier Belli, I'm committed to protecting your personal data. All applications and services are developed with privacy in mind, ensuring your information is handled transparently and securely.",
-      "policyLink": "Privacy Policy",
-      "choicesLink": "User Privacy Choices"
-    },
-    "contact": {
-      "title": "Let's talk about your Project",
-      "description": "Do you have an idea or need help with development? Don't hesitate to contact me.",
-      "cta": "Send an Email"
+    "cta": {
+      "eyebrow": "Commissions open",
+      "titlePre": "Let's build something ",
+      "titleIt": "well-made.",
+      "writeTo": "Write to",
+      "worldwide": "Worldwide"
     },
     "footer": {
-      "rights": "All rights reserved.",
-      "terms": "Terms and Conditions",
-      "privacy": "Privacy Policy"
+      "privacy": "Privacy",
+      "terms": "Terms"
     },
-    "languageSelector": {
-      "title": "Choose your language",
-      "description": "Select your preferred language to continue",
-      "english": "English",
-      "spanish": "Español",
-      "continue": "Continue"
+    "modal": {
+      "close": "Close"
     },
-    "notFound": {
-      "title": "Page Not Found",
-      "description": "Sorry, the page you're looking for doesn't exist or has been moved.",
-      "backHome": "Back to Home"
+    "cases": {
+      "meta": {
+        "platform": "Platform",
+        "stack": "Stack",
+        "status": "Status",
+        "year": "Year"
+      },
+      "fingo": {
+        "titleIt": "group choice, made easy.",
+        "descRich": "An iOS app for making group decisions instantly — wheels, coins, spinning arrows, tap-to-choose. Fully customizable, with <it>haptics</it> that make each pick feel deliberate. Built with SwiftUI.",
+        "metaStatus": "Live on the App Store",
+        "actionPrimary": "View on App Store",
+        "actionGhost": "Support",
+        "tag": "Wheels, coins, haptics — decisions in a tap."
+      },
+      "savely": {
+        "titleIt": "personal finance, quietly.",
+        "descRich": "A calm financial assistant. Track spending, save with goals, get smart alerts before things slip. Bank-grade security, <it>quiet</it> interface. Built with SwiftUI and secure banking APIs.",
+        "metaStatus": "In review · App Store soon",
+        "actionPrimary": "Coming soon",
+        "actionGhost": "Support",
+        "tag": "Balance, budgets, alerts — a calm financial assistant."
+      },
+      "mezcal": {
+        "descRich": "Storefront and story for an artisanal mezcal brand out of Oaxaca. A quiet, editorial site built to sell — varieties, origin, direct orders. <it>Hand-built</it> from brand to checkout.",
+        "metaPlatform": "Web · Responsive",
+        "metaStatus": "Live",
+        "actionPrimary": "Visit site",
+        "tag": "An artisanal mezcal brand — storefront and story."
+      }
     }
   }
-  
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,67 +1,107 @@
 {
-    "navigation": {
+  "notFound": {
+    "title": "Página No Encontrada",
+    "description": "Lo sentimos, la página que estás buscando no existe o ha sido movida.",
+    "backHome": "Volver al Inicio"
+  },
+  "layout": {
+    "skipToContent": "Ir al contenido principal"
+  },
+  "home": {
+    "nav": {
       "home": "Inicio",
+      "work": "Proyectos",
       "about": "Sobre mí",
-      "apps": "Apps",
-      "privacy": "Privacidad",
       "contact": "Contacto"
     },
+    "locale": {
+      "switchAria": "Switch to English"
+    },
+    "theme": {
+      "toggleAria": "Cambiar tema"
+    },
     "hero": {
-      "title": "Atelier Belli",
-      "subtitle": "Desarrollo de software y soluciones digitales",
-      "cta": "Ver mi trabajo"
+      "eyebrow": "Software · Oficio digital",
+      "titleLine1": "Apps hechas",
+      "titleLine2": "con ",
+      "titleIt": "intención.",
+      "subtitle": "Un pequeño <it>atelier</it> de software desde Tijuana. Forma minimalista, y la paciencia de terminar las cosas. Diseño y construyo apps de iOS y la web que las acompaña."
     },
-    "about": {
-      "title": "Sobre mí",
-      "description": "Soy un desarrollador full-stack apasionado por crear experiencias digitales pulcras y eficientes. Con un pie en la precisión técnica y otro en la elegancia del diseño minimalista, busco la armonía en cada línea de código. Mi enfoque franco-italiano se refleja en soluciones robustas con un toque de estilo distintivo. ¡Bienvenido a mi atelier digital!"
+    "colophon": {
+      "locationLabel": "Ubicación",
+      "statusLabel": "Estado",
+      "status": "Disponible para encargos",
+      "ongoing": "En curso",
+      "signed": "Firmado"
     },
-    "apps": {
-      "title": "Mis Aplicaciones",
-      "fingo": {
-        "title": "Fingo",
-        "description": "Fingo es la app definitiva para tomar decisiones en grupo al instante: elige con toques, ruletas, flechas giratorias o lanzamientos de moneda. Totalmente personalizable, con háptics que hacen cada elección rápida, divertida y justa."
-      },
-      "savely": {
-        "title": "Savely",
-        "description": "Savely es tu asistente de finanzas personales: controla tus gastos, ahorra con metas personalizadas y recibe alertas inteligentes para mantener tu presupuesto en orden. Diseño intuitivo y seguridad bancaria garantizada."
-      },
-      "mezcal": {
-        "title": "Mi Mezcal",
-        "description": "Descubre Mi Mezcal, el sitio web de mi marca de mezcal artesanal: conoce nuestra historia, explora variedades y haz tu pedido directo. Diseño elegante y experiencia de usuario auténtica."
-      },
-      "buttons": {
-        "support": "Soporte",
-        "appStore": "Ver en App Store",
-        "visitSite": "Visitar sitio"
+    "vitrine": {
+      "eyebrow": "Vitrina — 2025",
+      "titlePre": "Tres piezas ",
+      "titleIt": "recientes.",
+      "hint": "— Pasa el cursor para enfocar"
+    },
+    "work": {
+      "eyebrow": "La obra",
+      "titlePre": "Obra ",
+      "titleIt": "selecta.",
+      "indexMeta": "Índice — 2023 / 2026",
+      "viewCase": "Ver proyecto"
+    },
+    "workbench": {
+      "eyebrow": "El taller",
+      "titlePre": "Herramientas del ",
+      "titleIt": "oficio.",
+      "desc": "Un conjunto pequeño y opinado. Swift y SwiftUI para el teléfono; <it>Next.js</it> y TypeScript para la web; Postgres para lo que debe durar. Figma, Xcode, Claude Code — el banco se mantiene limpio.",
+      "groups": {
+        "frontend": "Frontend & Móvil",
+        "backend": "Backend & Infra",
+        "craft": "Oficio"
       }
     },
-    "privacy": {
-      "title": "Tu Privacidad es Importante",
-      "description": "En Atelier Belli, me comprometo a proteger tus datos personales. Todas las aplicaciones y servicios se desarrollan con la privacidad en mente, asegurando que tu información se maneje de forma transparente y segura.",
-      "policyLink": "Política de Privacidad",
-      "choicesLink": "Opciones de Privacidad del Usuario"
-    },
-    "contact": {
-      "title": "Hablemos de tu Proyecto",
-      "description": "¿Tienes una idea o necesitas ayuda con un desarrollo? No dudes en contactarme.",
-      "cta": "Enviar un Email"
+    "cta": {
+      "eyebrow": "Encargos abiertos",
+      "titlePre": "Hagamos algo ",
+      "titleIt": "bien hecho.",
+      "writeTo": "Escribe a",
+      "worldwide": "Todo el mundo"
     },
     "footer": {
-      "rights": "Todos los derechos reservados.",
-      "terms": "Términos y Condiciones",
-      "privacy": "Política de Privacidad"
+      "privacy": "Privacidad",
+      "terms": "Términos"
     },
-    "languageSelector": {
-      "title": "Elige tu idioma",
-      "description": "Selecciona tu idioma preferido para continuar",
-      "english": "English",
-      "spanish": "Español",
-      "continue": "Continuar"
+    "modal": {
+      "close": "Cerrar"
     },
-    "notFound": {
-      "title": "Página No Encontrada",
-      "description": "Lo sentimos, la página que estás buscando no existe o ha sido movida.",
-      "backHome": "Volver al Inicio"
+    "cases": {
+      "meta": {
+        "platform": "Plataforma",
+        "stack": "Stack",
+        "status": "Estado",
+        "year": "Año"
+      },
+      "fingo": {
+        "titleIt": "decisiones en grupo, fácil.",
+        "descRich": "Una app de iOS para decidir en grupo al instante — ruletas, monedas, flechas giratorias, toque-para-elegir. Totalmente personalizable, con <it>háptics</it> que hacen que cada elección se sienta intencional. Construida con SwiftUI.",
+        "metaStatus": "Disponible en App Store",
+        "actionPrimary": "Ver en App Store",
+        "actionGhost": "Soporte",
+        "tag": "Ruletas, monedas, háptics — decisiones de un toque."
+      },
+      "savely": {
+        "titleIt": "finanzas personales, en calma.",
+        "descRich": "Un asistente financiero tranquilo. Rastrea gastos, ahorra con metas, recibe alertas inteligentes antes de que las cosas se salgan. Seguridad bancaria, interfaz <it>silenciosa</it>. Construida con SwiftUI y APIs bancarias seguras.",
+        "metaStatus": "En revisión · Próximamente",
+        "actionPrimary": "Próximamente",
+        "actionGhost": "Soporte",
+        "tag": "Balance, presupuesto, alertas — un asistente financiero tranquilo."
+      },
+      "mezcal": {
+        "descRich": "Tienda e historia para una marca de mezcal artesanal de Oaxaca. Un sitio editorial y tranquilo construido para vender — variedades, origen, pedidos directos. <it>Hecho a mano</it> de la marca al checkout.",
+        "metaPlatform": "Web · Responsiva",
+        "metaStatus": "En vivo",
+        "actionPrimary": "Visitar sitio",
+        "tag": "Una marca de mezcal artesanal — tienda e historia."
+      }
     }
   }
-  
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,6 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  serverExternalPackages: ['next-intl'],
   trailingSlash: true,
 };
  


### PR DESCRIPTION
## Summary

Replaces all legacy `const isSpanish = locale === 'es'` ternaries in
`app/[locale]/page.tsx` and the inline skip-link literal in
`app/[locale]/layout.tsx` with the canonical next-intl pattern.
Reintroduces `NextIntlClientProvider` in the locale layout so Client
Components can call `useTranslations()`. Removes
`serverExternalPackages: ['next-intl']` from `next.config.mjs` (was
redundant with `createNextIntlPlugin` and blocked the prerender
resolution).

~38 `t()` and 5 `t.rich()` call sites added. ~870-line homepage diff.

## Gotchas honored
- `i18n-pattern-canonical` — homepage and layout now use `useTranslations()` / `getTranslations()`. Stale top-level dictionary keys cleaned up.
- `amplify-client-component-quirk` — **explicitly cited**. The reintroduced `NextIntlClientProvider` is the construct commit `5719a20` removed for Amplify reasons in 2025-08 on Next 14. We are now on Next 15.2.4 + React 19. The regression may no longer reproduce but is UNVERIFIED — Amplify smoke required before merge.

## ⚠️ Amplify smoke required before merge
The deploy preview must be visited at `/en` and `/es` and on each support/legal route. Confirm:
- [ ] Homepage renders without runtime errors (check browser console).
- [ ] EN ↔ ES locale toggle still works.
- [ ] Theme toggle (light/dark) still works.
- [ ] Modal opens (click any case → confirm copy localizes).
- [ ] No `MISSING_MESSAGE` warning in browser console.

If any check fails, revert this PR. PRs 1 and 2 are independent and not affected.

## Test plan
- [x] `pnpm exec tsc --noEmit` — green
- [x] `pnpm build` — green, all 15 static pages generated
- [ ] Local visual smoke on `/en` and `/es` (in `pnpm dev`)
- [ ] **Amplify deploy preview smoke** ← required
- [ ] PR 4 (privacy/terms full bilingual) is BLOCKED on this merge + Amplify confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)