### PR TITLE
Fill legal-page placeholders with real values

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -82,8 +82,8 @@
           "heading": "Contact",
           "body": "If you have questions or comments about this Privacy Policy, please contact us at:",
           "name": "Atelier Belli",
-          "email": "[Your Privacy Contact Email Address]",
-          "address": "[Your Physical Address, if applicable]"
+          "email": "ivanlorenzanabelli@outlook.com",
+          "address": "Tijuana, Baja California, Mexico"
         }
       }
     },
@@ -93,7 +93,7 @@
       "sections": {
         "access": {
           "heading": "Access to Your Information",
-          "body": "You have the right to request a copy of the personal information we hold about you. You may do so by contacting us through [Contact Method for Access Requests, e.g. email@atelierbelli.com]."
+          "body": "You have the right to request a copy of the personal information we hold about you. You may do so by contacting us at ivanlorenzanabelli@outlook.com."
         },
         "correction": {
           "heading": "Correction of Your Information",
@@ -119,7 +119,7 @@
           "heading": "How to Exercise Your Rights",
           "contactIntro": "To exercise any of these rights, please contact us at:",
           "name": "Atelier Belli — Privacy Department",
-          "email": "Email: [Your Privacy Contact Email, e.g. privacy@atelierbelli.com]",
+          "email": "Email: ivanlorenzanabelli@outlook.com",
           "responseNote": "We will respond to your request within the legally required timeframe. We may need to verify your identity before processing your request.",
           "disclaimer": "Please note that these rights are not absolute and may be subject to certain exemptions under applicable law."
         }
@@ -158,7 +158,7 @@
         },
         "governingLaw": {
           "heading": "6. Governing Law",
-          "body": "These Terms shall be governed by and construed in accordance with the laws of [Your Jurisdiction, e.g. the State of..., the Country of...], without regard to its conflict-of-law principles."
+          "body": "These Terms shall be governed by and construed in accordance with the laws of the State of Baja California, Mexico, without regard to its conflict-of-law principles."
         },
         "limitationOfLiability": {
           "heading": "7. Limitation of Liability",
@@ -173,7 +173,7 @@
           "body": "To resolve a complaint regarding the Services or to receive further information regarding use of the Services, please contact us at:",
           "name": "Atelier Belli",
           "email": "contacto@atelierbelli.com",
-          "address": "[Your Physical Address, if applicable]"
+          "address": "Tijuana, Baja California, Mexico"
         }
       }
     }

--- a/messages/es.json
+++ b/messages/es.json
@@ -82,8 +82,8 @@
           "heading": "Contacto",
           "body": "Si tienes preguntas o comentarios sobre esta Política de Privacidad, por favor contáctanos en:",
           "name": "Atelier Belli",
-          "email": "[Tu Dirección de Correo Electrónico de Contacto para Privacidad]",
-          "address": "[Tu Dirección Física, si aplica]"
+          "email": "ivanlorenzanabelli@outlook.com",
+          "address": "Tijuana, Baja California, México"
         }
       }
     },
@@ -93,7 +93,7 @@
       "sections": {
         "access": {
           "heading": "Acceso a Tu Información",
-          "body": "Tienes derecho a solicitar una copia de la información personal que tenemos sobre ti. Puedes hacerlo contactándonos a través de [Método de Contacto para Solicitudes de Acceso, ej. email@atelierbelli.com]."
+          "body": "Tienes derecho a solicitar una copia de la información personal que tenemos sobre ti. Puedes hacerlo escribiéndonos a ivanlorenzanabelli@outlook.com."
         },
         "correction": {
           "heading": "Corrección de Tu Información",
@@ -119,7 +119,7 @@
           "heading": "Cómo Ejercer Tus Derechos",
           "contactIntro": "Para ejercer cualquiera de estos derechos, por favor contáctanos en:",
           "name": "Atelier Belli - Departamento de Privacidad",
-          "email": "Email: [Tu Email de Contacto para Privacidad, ej. privacy@atelierbelli.com]",
+          "email": "Email: ivanlorenzanabelli@outlook.com",
           "responseNote": "Responderemos a tu solicitud dentro del plazo legalmente requerido. Es posible que necesitemos verificar tu identidad antes de procesar tu solicitud.",
           "disclaimer": "Ten en cuenta que estos derechos no son absolutos y pueden estar sujetos a ciertas exenciones bajo la ley aplicable."
         }
@@ -158,7 +158,7 @@
         },
         "governingLaw": {
           "heading": "6. Ley Aplicable",
-          "body": "Estos Términos se regirán e interpretarán de acuerdo con las leyes de [Tu Jurisdicción, ej. el Estado de..., el País de...], sin tener en cuenta sus principios de conflicto de leyes."
+          "body": "Estos Términos se regirán e interpretarán de acuerdo con las leyes del Estado de Baja California, México, sin tener en cuenta sus principios de conflicto de leyes."
         },
         "limitationOfLiability": {
           "heading": "7. Limitación de Responsabilidad",
@@ -173,7 +173,7 @@
           "body": "Para resolver una queja sobre los Servicios o para recibir más información sobre el uso de los Servicios, por favor contáctenos en:",
           "name": "Atelier Belli",
           "email": "contacto@atelierbelli.com",
-          "address": "[Tu Dirección Física, si aplica]"
+          "address": "Tijuana, Baja California, México"
         }
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #12 (legal-pages bilingual rewrite). Replaces the six
bracket placeholders that were carried over from the original
Spanish copy with real values.

- Privacy contact email → `ivanlorenzanabelli@outlook.com`
- Physical address → `Tijuana, Baja California, Mexico` / `Tijuana, Baja California, México`
- Governing-law jurisdiction → `the State of Baja California, Mexico` / `el Estado de Baja California, México`

`legal.terms.sections.contact.email` (already `contacto@atelierbelli.com`)
was not changed.

## Gotchas honored

No gotcha triggers matched this diff (pure JSON content change, no source code touched).

## Test plan
- [x] `grep -nE '\[Your |\[Tu '` on both dictionaries returns zero matches
- [x] `pnpm exec tsc --noEmit` — green
- [x] `pnpm build` — green, all 15 static pages generate
- [ ] Visual smoke `/en/privacy`, `/es/privacy`, `/en/privacy/choices`, `/es/privacy/choices`, `/en/terms`, `/es/terms` — confirm contact email and jurisdiction render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)