### PR TITLE
Refresh CLAUDE.md + gotchas + agent docs post-cleanup

### DIFF
--- a/.claude/agents/content-i18n-specialist.md
+++ b/.claude/agents/content-i18n-specialist.md
@@ -19,14 +19,21 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
 
 ## Scope rules
 
-- New code uses `useTranslations()` from `next-intl`. Keys belong in
-  `messages/*.json`. See gotcha `i18n-pattern-canonical`.
-- Legacy inline `isSpanish` flags exist in most pages. Do NOT introduce new
-  ones. Migrating existing flags to `useTranslations()` is opportunistic —
-  only do it when the request already has you editing that page.
-- Spanish is not a word-for-word translation of English. The support pages
-  and homepage copy use idiomatic ES written by the owner. Match that
-  voice; don't auto-translate verbatim.
+- All code uses `useTranslations()` (Client) or `getTranslations()` (Server)
+  from `next-intl`. Keys belong in `messages/*.json`. The full migration
+  off `const isSpanish = locale === 'es'` shipped in PRs #9 and #12
+  (2026-04-25). NEVER reintroduce that pattern. See gotcha
+  `i18n-pattern-canonical`.
+- Top-level namespaces in use today: `notFound`, `layout`, `legal`, `home`.
+  When adding new copy, pick the right namespace or create a new one if the
+  surface is genuinely new. Keep nesting shallow (≤2 levels).
+- Spanish is not a word-for-word translation of English. The homepage,
+  legal-page, and support-page copy use idiomatic ES written by the owner.
+  Match that voice; don't auto-translate verbatim. EN should be natural
+  English, not literal.
+- For rich strings with embedded JSX (e.g. an `<em>` accent), use ICU
+  placeholder tags in the dictionary value (`<it>...</it>`) — the consumer
+  passes a chunks function via `t.rich()`.
 - Route structure (`/[locale]/...`) and the middleware matcher are
   load-bearing. Changing supported locales or the default is a user-facing
   decision — ask first.
@@ -41,27 +48,32 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
 
 - The user request with target locale(s) or copy.
 - Matched gotcha ids with rule text.
-- Reference: the homepage's `isSpanish` ternary structure in
-  `app/[locale]/page.tsx` and the `SupportContent` dictionaries in the
-  two support pages.
+- Reference: the existing key shape of `home.*`, `legal.*`, `layout.*`,
+  `notFound.*` in `messages/en.json` / `messages/es.json` — pattern-match
+  to those when designing new keys.
 
 ## What to return
 
 1. Files changed (paths + which keys/strings).
-2. If a string was migrated from inline to `useTranslations()`, the JSON
-   keys added on each side (en + es).
+2. The full list of new keys created with EN + ES values (so the frontend
+   specialist can sanity-check the schema without re-reading the JSON).
 3. Visual smoke result: did you load `/en/` and `/es/` in `pnpm dev` to
    verify the new copy renders?
 4. If the request touched `middleware.ts` or `i18n.ts`, flag
    `security-reviewer` in the handoff — middleware changes trigger the
    security gate.
+5. If the request touched `app/[locale]/layout.tsx` (provider/setRequestLocale
+   wiring), flag the Amplify-smoke gate from gotcha
+   `amplify-client-component-quirk`.
 
 ## Current state
 
-- `useTranslations()` is used only in `app/[locale]/not-found.tsx`.
-- `messages/en.json` and `messages/es.json` have scaffolded keys for older
-  copy (`hero`, `apps`, `about`, etc.) but the homepage no longer reads them;
-  the homepage's current copy is inline.
-- Support pages' content dictionaries live inline in each page's `CONTENT`
-  const — moving those to `messages/*.json` is a future opportunistic
-  migration.
+- Every locale-scoped page consumes `useTranslations(...)` or
+  `getTranslations(...)`. Zero `isSpanish` references in the source tree.
+- `messages/en.json` and `messages/es.json` top-level keys: `notFound`,
+  `layout`, `legal`, `home`. All four are live; no orphan namespaces.
+- Support pages still read content from inline `CONTENT[locale]` dictionaries
+  in each page's source — that's a different (acceptable) pattern from
+  next-intl, used for the heavy SUPPORT body text. Moving those into
+  `messages/*.json` is a future opportunistic migration; the homepage and
+  legal pages already finished theirs.

--- a/.claude/agents/frontend-ui-specialist.md
+++ b/.claude/agents/frontend-ui-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-ui-specialist
-description: Owns React UI, Tailwind, shadcn, tokens, and the two scoped root stylesheets (.ab-root / .sup-root). Use for homepage/support/utility-page changes that are visual, interactive, or structural.
+description: Owns React UI, Tailwind, design tokens, and the two scoped root stylesheets (.ab-root / .sup-root, plus .ab-prose / .ab-legal-* for legal pages). Use for homepage/support/legal-page changes that are visual, interactive, or structural.
 model: sonnet
 tools: Read, Edit, Write, Grep, Glob, Bash
 ---
@@ -12,9 +12,9 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
 ## Ownership
 
 - `app/[locale]/**/*.tsx` (all pages and the locale layout)
-- `components/*.tsx` (SupportShell, SimplePageLayout)
-- `components/ui/**` (shadcn scaffold)
-- `app/globals.css` — the single stylesheet; all design system tokens
+- `components/*.tsx` (SupportShell — the only shared component today)
+- `app/globals.css` — the single stylesheet; all design system tokens,
+  the `.ab-root` (incl. `.ab-prose` + `.ab-legal-*`) and `.sup-root` rules
 - `tailwind.config.ts` — content glob and theme extensions
 - `public/**` — static assets referenced by the UI (images, SVGs, favicons)
 
@@ -22,15 +22,18 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
 
 - `.ab-root` and `.sup-root` token sets do NOT cross. See gotcha
   `root-token-scoping`. When adding a color/spacing/type variable, pick the
-  correct root or extract to `:root` if it's global.
-- Legacy pages (`/privacy`, `/terms`, `/privacy/choices`) use
-  `SimplePageLayout` with the gray/gradient aesthetic. Do not convert them
-  to `.ab-root` / `.sup-root` as a side effect; that's a dedicated
-  refactor request.
+  correct root or extract to `:root` if it's global. Note that legal-page
+  chrome (`.ab-legal-*`) and `.ab-prose` are scoped UNDER `.ab-root` —
+  same token vocabulary as the homepage.
+- The `i18n-pattern-canonical` migration is COMPLETE. Every locale page
+  uses `useTranslations()` (Client) or `getTranslations()` (Server). NEVER
+  reintroduce a `const isSpanish = locale === 'es'` ternary.
 - Any new copy belongs to `content-i18n-specialist`; surface the string slot
-  and hand off.
+  (key path + EN/ES draft if you have it) and hand off.
 - Any `next.config.mjs` / `package.json` change belongs to
-  `infra-deploy-specialist`.
+  `infra-deploy-specialist`. Any change to the i18n provider wiring in
+  `app/[locale]/layout.tsx` requires the Amplify-smoke gate — see gotcha
+  `amplify-client-component-quirk`.
 
 ## Files you must NOT touch
 
@@ -58,10 +61,17 @@ A short report with:
 
 ## Notes on current state
 
-- Homepage (`app/[locale]/page.tsx`) is ~930 lines. Do not start a rewrite
-  without explicit user agreement — incremental edits only.
-- `components/ui/` has 50 shadcn components, most unused by current pages.
-  Reach for them before hand-rolling equivalents.
+- Homepage (`app/[locale]/page.tsx`) is ~870 lines after the i18n migration.
+  Do not start a rewrite without explicit user agreement — incremental
+  edits only.
+- No component library today: `components/ui/`, `hooks/`, and `lib/utils.ts`
+  were all removed in PR #7. If you need a primitive, hand-roll it matching
+  the editorial aesthetic, or have the user re-introduce shadcn explicitly
+  (`pnpm dlx shadcn@latest add <component>`) — don't sneak it in.
+- Legal pages (`/privacy`, `/privacy/choices`, `/terms`) are inline
+  `.ab-root` shells. The chrome (`.ab-legal-*`) and prose ruleset
+  (`.ab-prose`) live in `globals.css`. Re-use them rather than building
+  parallel shells if you add a new utility page.
 - Reveal-on-scroll uses vanilla `IntersectionObserver` + CSS; no animation
-  library is loaded today (framer-motion was removed). Keep it that way
-  unless the user asks for a different trade-off.
+  library is loaded today (framer-motion was removed in PR #6). Keep it
+  that way unless the user asks for a different trade-off.

--- a/.claude/agents/infra-deploy-specialist.md
+++ b/.claude/agents/infra-deploy-specialist.md
@@ -23,7 +23,11 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
 
 - `images.unoptimized: true` is load-bearing for Amplify. Do NOT remove. See
   gotcha `amplify-images-unoptimized`.
-- `serverExternalPackages: ['next-intl']` is load-bearing. Do NOT remove.
+- `createNextIntlPlugin('./i18n.ts')` wraps the config export. Do NOT
+  unwrap it — next-intl's RSC integration depends on the plugin.
+- `serverExternalPackages: ['next-intl']` was REMOVED in PR #9 (2026-04-25)
+  because it was redundant with the plugin and prevented `useTranslations()`
+  from resolving the `react-server` export at SSG. Do NOT reintroduce it.
 - `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` are currently
   `true`. Flipping either to `false` is a user-facing decision — ask first.
 - Dep changes are always their own PR. See gotcha
@@ -31,9 +35,11 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
   feature commit.
 - Package manager is pnpm. Never suggest npm/yarn. See gotcha
   `pnpm-is-package-manager`.
-- Any change to the client-component / server-component boundary impacts
-  Amplify — see gotcha `amplify-client-component-quirk` before touching
-  `app/[locale]/layout.tsx` or `middleware.ts`.
+- Any change to the i18n provider wiring impacts Amplify — see gotcha
+  `amplify-client-component-quirk` before touching
+  `app/[locale]/layout.tsx`, `i18n.ts`, the `next-intl` plugin, or
+  `middleware.ts`. Smoke-test on Amplify deploy preview before merging to
+  main when this region changes.
 
 ## Files you must NOT touch
 
@@ -64,8 +70,11 @@ Read `.claude/knowledge/common-rules.md` at the start of every invocation.
 ## Current state
 
 - Scripts: `dev`, `build`, `start`, `lint`. No `typecheck` or `test` script.
-- Dead deps were just removed (three, @react-three/fiber, @react-three/drei,
-  framer-motion, react-parallax-tilt, @types/three) — change is in working
-  tree pending its own commit.
+- Dep tree is clean as of 2026-04-25. Two cleanup PRs landed: PR #6
+  (three, @react-three/fiber, @react-three/drei, framer-motion,
+  react-parallax-tilt, @types/three) and PR #11 (next-themes, sonner).
+- `next.config.mjs` is minimal: `images.unoptimized`, `trailingSlash`,
+  the two `ignoreBuildErrors`/`ignoreDuringBuilds` flags, all wrapped by
+  `createNextIntlPlugin`. No `serverExternalPackages` entry.
 - No `amplify.yml`, no `.github/workflows/` — adding either is a user-
   facing decision.

--- a/.claude/knowledge/gotchas.yaml
+++ b/.claude/knowledge/gotchas.yaml
@@ -13,16 +13,20 @@
       - "--sup-"
       - ".ab-root"
       - ".sup-root"
+      - ".ab-prose"
+      - ".ab-legal-"
       - "data-theme"
       - "data-app"
   rule: >-
-    Tokens prefixed --ab-* live ONLY under .ab-root (homepage). Tokens
-    prefixed --sup-* live ONLY under .sup-root (support pages). Neither set
-    may leak across. Global tokens for shadcn (--background, --foreground,
-    --border, etc.) live in :root and .dark. When a new component needs a
-    color, first decide which scope it lives in, then reach for that scope's
-    prefixed vars. Do not redeclare the same token name under both roots —
-    extract to :root instead.
+    Tokens prefixed --ab-* live ONLY under .ab-root (homepage AND the legal-
+    page chrome via .ab-legal-* / .ab-prose, which are scoped under .ab-root
+    in globals.css). Tokens prefixed --sup-* live ONLY under .sup-root
+    (support pages, data-app="fingo" or "savely"). Neither set may leak
+    across. Global HSL tokens (--background, --foreground, --border, etc.)
+    live in :root and .dark; they're consumed by Tailwind's theme extension.
+    When a new component needs a color, first decide which scope it lives
+    in, then reach for that scope's prefixed vars. Do not redeclare the
+    same token name under both roots — extract to :root instead.
   source: "CLAUDE.md#4-design-system"
 
 - id: i18n-pattern-canonical
@@ -33,17 +37,24 @@
       - "messages/*.json"
     keywords:
       - "useTranslations"
+      - "getTranslations"
       - "isSpanish"
       - "next-intl"
       - "useParams"
+      - "NextIntlClientProvider"
   rule: >-
-    Canonical i18n for NEW code: useTranslations() from next-intl, keys in
-    messages/en.json and messages/es.json. Legacy inline flags (const
-    isSpanish = locale === 'es') exist in most pages due to an Amplify-
-    triggered migration (see gotcha amplify-client-component-quirk). Do NOT
-    introduce new inline isSpanish code unless a concrete Amplify regression
-    is reproduced first. Migration of existing pages to useTranslations() is
-    opportunistic, not a blocker on unrelated work.
+    Canonical i18n: useTranslations() in Client Components, getTranslations()
+    in Server Components. Keys in messages/en.json + messages/es.json. Top-
+    level namespaces in use today: notFound, layout, legal, home. The full
+    migration landed in PRs #9 and #12 (2026-04-25); zero `isSpanish`
+    ternaries remain in the source tree. NEVER reintroduce `const isSpanish
+    = locale === 'es'` or any equivalent ternary against a translation
+    string. New copy always goes through next-intl keys. useParams().locale
+    is still acceptable for routing logic (href construction, switchLocale
+    helper, language-code chip labels) — that is not a translation concern.
+    For rich strings with embedded JSX, use ICU placeholder tags in the
+    dictionary value and t.rich(key, { tag: chunks => <em>{chunks}</em> })
+    in the consumer.
   source: "CLAUDE.md#5-i18n"
 
 - id: amplify-images-unoptimized
@@ -72,24 +83,33 @@
       - "app/[locale]/layout.tsx"
       - "app/**/*.tsx"
       - "middleware.ts"
+      - "next.config.mjs"
+      - "i18n.ts"
     keywords:
       - "NextIntlClientProvider"
       - "getMessages"
+      - "getTranslations"
       - "useTranslations"
-      - "useParams"
-      - "usePathname"
+      - "unstable_setRequestLocale"
+      - "serverExternalPackages"
+      - "createNextIntlPlugin"
   rule: >-
-    Historical commit 5719a20 (2025-08-13, "Fix client component issues for
-    Amplify") stripped NextIntlClientProvider + getMessages() from the
-    locale layout, migrated useTranslations() calls to inline isSpanish
-    flags, and switched useParams() to usePathname() for locale extraction —
-    because the async provider setup failed under Amplify's static export
-    model. After the 2026-04 redesign, the homepage was rewritten to use
-    useParams() again and works in dev, but its Amplify behavior is
-    UNVERIFIED. If an Amplify build or runtime regression surfaces around
-    i18n, start by (a) confirming no NextIntlClientProvider was reintroduced
-    upstream of a 'use client' tree, and (b) falling back to usePathname() +
-    inline isSpanish for the failing route.
+    Current setup (PR #9, 2026-04-25): app/[locale]/layout.tsx wraps
+    {children} in NextIntlClientProvider with messages from getMessages(),
+    and calls unstable_setRequestLocale(locale) before any
+    getTranslations/getMessages read. The provider is required for Client
+    Component useTranslations() to work; setRequestLocale is required to
+    keep all routes statically prerendered. createNextIntlPlugin('./i18n.ts')
+    wraps the next.config.mjs export. serverExternalPackages: ['next-intl']
+    was REMOVED in PR #9 — it was redundant with the plugin and prevented
+    useTranslations() from resolving the react-server export at SSG. This
+    full setup was Amplify-smoked successfully on Next 15.2.4 + React 19;
+    the historical break (commit 5719a20, 2025-08-13, on Next 14) no longer
+    reproduces. FORWARD-LOOKING RULE: if you change anything about the
+    provider position, message loading, setRequestLocale call, or the
+    next-intl plugin wiring — smoke-test on an Amplify deploy preview
+    before merging to main. Do NOT trust local pnpm build alone for changes
+    in this region.
   source: "CLAUDE.md#6-amplify-quirks"
 
 - id: dead-deps-removal-dedicated-pr
@@ -98,22 +118,26 @@
       - "package.json"
       - "pnpm-lock.yaml"
     keywords:
-      - "three"
-      - "framer-motion"
-      - "react-parallax-tilt"
-      - "@react-three"
       - "pnpm remove"
       - "pnpm add"
+      - "next-themes"
+      - "sonner"
+      - "three"
+      - "framer-motion"
+      - "@react-three"
   rule: >-
-    After the 2026-04 editorial redesign, five deps (three,
-    @react-three/fiber, @react-three/drei, framer-motion,
-    react-parallax-tilt) and one devDep (@types/three) were uninstalled.
-    That removal is pending its own dedicated commit/PR as of 2026-04-24,
-    not bundled with unrelated work. Before shipping any future dep removal,
-    (1) grep the codebase for every import of the package, (2) run pnpm
-    build to confirm compile, (3) load /en/ and /es/ in pnpm dev as visual
-    smoke, (4) commit with a message naming what was removed and why. Never
-    remove a dep as a drive-by in an unrelated feature PR.
+    Two dep-removal waves shipped in 2026-04-25: PR #6 dropped six packages
+    orphaned by the editorial redesign (three, @react-three/fiber,
+    @react-three/drei, framer-motion, react-parallax-tilt, @types/three),
+    PR #11 dropped two more orphaned by the shadcn scaffold deletion
+    (next-themes, sonner). Both followed the dedicated-PR pattern. Going
+    forward, ANY dep removal must be its own PR — never bundled with
+    unrelated feature or refactor work. Before shipping a dep removal:
+    (1) grep the source tree for every import of the package
+    ('grep -rE "from ['\"]<pkg>" app components' — note that lib/, hooks/,
+    and components/ui/ no longer exist), (2) run pnpm build to confirm
+    compile, (3) load /en/ and /es/ in pnpm dev as visual smoke, (4) commit
+    with a message naming what was removed and why.
   source: "CLAUDE.md#7-dead-dependencies"
 
 - id: google-fonts-hybrid-loading

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,11 @@ one Next.js app:
   reusable `SupportShell` keyed by `data-app`, `.sup-root` scope, per-app skin
   (terracotta / green / gold).
 - **Utility sub-pages**: `/[locale]/privacy`, `/[locale]/privacy/choices`,
-  `/[locale]/terms` — use the legacy `SimplePageLayout` with the gray/gradient
-  aesthetic. Visually inconsistent with the homepage, intentional (separate
-  scope; redesign is opportunistic).
+  `/[locale]/terms` — small inline `.ab-root` shells with the same editorial
+  aesthetic as the homepage. Bilingual EN/ES bodies via
+  `useTranslations('legal')`. The shared chrome + `.ab-prose` ruleset live
+  in `app/globals.css`. (Previously used a legacy `SimplePageLayout` with
+  gray/gradient aesthetic — removed in PR #12.)
 
 Fully bilingual EN/ES. Static site (no database, no auth, no server actions).
 
@@ -56,9 +58,16 @@ Routing (via `middleware.ts` using `next-intl/middleware`):
 
 **Deploy**: AWS Amplify. No `amplify.yml` in the repo — build config is in the
 Amplify console. No `.github/workflows/` — there is no CI beyond Amplify.
-`next.config.mjs` sets `images.unoptimized: true` and
-`serverExternalPackages: ['next-intl']` — both are load-bearing, see gotchas
-`amplify-images-unoptimized` and `amplify-client-component-quirk`.
+`next.config.mjs` sets `images.unoptimized: true` (load-bearing for Amplify
+image delivery, see gotcha `amplify-images-unoptimized`) and wraps the export
+with `createNextIntlPlugin('./i18n.ts')` so next-intl's RSC integration
+resolves correctly during SSG.
+
+`app/[locale]/layout.tsx` wraps `{children}` in `NextIntlClientProvider`
+(messages from `getMessages()`) and calls `unstable_setRequestLocale(locale)`
+before any translation read so all routes stay statically prerendered. This
+setup was Amplify-smoked successfully on Next 15.2.4 + React 19 in PR #9.
+See gotcha `amplify-client-component-quirk`.
 
 `next.config.mjs` also sets `typescript.ignoreBuildErrors: true` and
 `eslint.ignoreDuringBuilds: true`. The build will not fail on type or lint
@@ -73,14 +82,19 @@ See gotcha `root-token-scoping`.
   cream/turquoise (light) vs. ink/turquoise (dark). Tokens prefixed `--ab-*`
   (`--ab-bg`, `--ab-fg`, `--ab-muted`, `--accent-color`, `--accent-soft`,
   `--accent-deep`, etc.) live under `.ab-root` only.
-- **`.sup-root`** — support pages. Attribute `data-app="fingo" | "savely" |
-  "lorenzana"` swaps the skin. Tokens prefixed `--sup-*` live under `.sup-root`
-  only. Three themes are defined; `lorenzana` is unused by any route today
-  (kept for a future Destilería support page).
+- **`.sup-root`** — support pages. Attribute `data-app="fingo" | "savely"`
+  swaps the skin. Tokens prefixed `--sup-*` live under `.sup-root` only.
+  (A `lorenzana` theme existed but was unused by any route; removed in
+  PR #8. Re-add later if a Destilería support page is built.)
+- **Legal-page chrome (`.ab-legal-*`) + `.ab-prose`** — scoped under
+  `.ab-root` in `app/globals.css`. Used by `/privacy`, `/privacy/choices`,
+  `/terms`. Token-only (`--ab-*` and global HSL); no `--sup-*` references.
 - **Global HSL tokens** (`--background`, `--foreground`, `--border`, etc.)
-  live in `:root` and `.dark` in `app/globals.css`. These are the shadcn/ui
-  surface, consumed by Tailwind's extended color palette. Independent from
-  the two scoped roots above.
+  live in `:root` and `.dark` in `app/globals.css`. Consumed by Tailwind's
+  extended color palette. Independent from the two scoped roots above.
+  (Originally the shadcn/ui surface; the scaffold itself was removed in
+  PR #7 and the tokens stay because Tailwind's theme extension still
+  references them.)
 
 **Typography stacks**:
 
@@ -90,28 +104,42 @@ See gotcha `root-token-scoping`.
 | `.sup-root`| EB Garamond / Instrument Serif for display; IBM Plex Mono for meta; Inter for body |
 | Global     | `--font-inter` from `next/font` on `<html>`, default sans fallback |
 
-**shadcn/ui**: 50 components in `components/ui/` (full scaffold, most unused).
-Add new ones with `pnpm dlx shadcn@latest add <component>`. `lib/utils.ts`
-exports `cn()` (clsx + tailwind-merge).
+**No component library today**: the shadcn scaffold (`components/ui/`,
+50 files), `hooks/`, and `lib/utils.ts` (with `cn()`) were all removed in
+PR #7 — none were imported by runtime code. If you genuinely need a
+primitive, either hand-roll it (matching the editorial aesthetic) or
+re-introduce shadcn via `pnpm dlx shadcn@latest add <component>` as a
+deliberate, explicit decision. Recreate `cn()` as a tiny helper if needed.
 
 ## 5. i18n
 
-**Canonical direction**: `useTranslations()` from `next-intl`, with keys in
-`messages/en.json` and `messages/es.json`. See gotcha `i18n-pattern-canonical`.
+**Canonical pattern**: `useTranslations()` in Client Components,
+`getTranslations()` in Server Components. Keys in `messages/en.json` and
+`messages/es.json`. See gotcha `i18n-pattern-canonical`.
 
-**Current reality**: only `app/[locale]/not-found.tsx` uses `useTranslations()`.
-Every other page uses an inline flag:
+**Current reality**: every locale-scoped page uses the canonical pattern.
+The legacy `const isSpanish = locale === 'es'` ternary was fully removed
+in PRs #9 (homepage + locale layout) and #12 (legal pages). Zero
+`isSpanish` references remain in the source tree. **Never reintroduce
+that pattern.**
 
-```ts
-const params = useParams()
-const locale = (params?.locale as string) === "es" ? "es" : "en"
-const isSpanish = locale === "es"
-```
+`useParams().locale` is still used for routing concerns — href construction
+like `/${locale}/privacy`, the `switchLocale()` helper, language-code chip
+labels (`"EN"`/`"ES"`). That is correct; routing is not a translation
+concern.
 
-This is the residue of the historical Amplify migration (see gotcha
-`amplify-client-component-quirk`). **New code MUST use `useTranslations()`**.
-Migration of existing inline flags is opportunistic, not a blocker on
-unrelated work.
+`messages/*.json` top-level namespaces in use: `notFound`, `layout`,
+`legal`, `home`. Adding new copy = pick the right namespace, add the key
+to BOTH dictionaries (EN value matches user-facing English; ES matches
+Spanish), then consume via `useTranslations(namespace)`.
+
+For rich strings with embedded JSX (e.g. `<em>` accents), use ICU placeholder
+tags in the dictionary value (`"Designed in <it>Tijuana</it> by Belli"`) and
+render via `t.rich(key, { it: (chunks) => <em>{chunks}</em> })`.
+
+`app/[locale]/layout.tsx` wires the provider + `setRequestLocale`. See
+section 6 (Amplify quirks) and gotcha `amplify-client-component-quirk` for
+why both are required.
 
 ## 6. Amplify quirks
 
@@ -121,66 +149,79 @@ are load-bearing:
 1. **`images.unoptimized: true`** in `next.config.mjs` — Amplify's image proxy
    does not match Next/Image's sharp defaults. Removing this setting breaks
    image delivery. See gotcha `amplify-images-unoptimized`.
-2. **`serverExternalPackages: ['next-intl']`** — Next 15 renamed this from
-   `experimental.serverComponentsExternalPackages`. Keeps `next-intl` out of
-   the server-bundle rewrite, required for the Amplify runtime.
-3. **The client-component + i18n trap** — commit `5719a20` ("Fix client
-   component issues for Amplify", 2025-08-13) removed
-   `NextIntlClientProvider` + `getMessages()` from `app/[locale]/layout.tsx`,
-   migrated `useTranslations()` calls to inline `isSpanish`, and switched
-   `useParams()` to `usePathname()` for locale extraction. The 2026-04
-   redesign reintroduced `useParams()` in the homepage — **works in dev,
-   unverified on Amplify**. See gotcha `amplify-client-component-quirk`.
-4. **No env-var usage in any Client Component**. Only `NEXT_PUBLIC_*` vars
+2. **i18n provider + `unstable_setRequestLocale`** —
+   `app/[locale]/layout.tsx` wraps `{children}` in
+   `<NextIntlClientProvider messages={messages}>` (messages from
+   `getMessages()`) and calls `unstable_setRequestLocale(locale)` before any
+   `getTranslations`/`getMessages` read. The provider is required for
+   Client Component `useTranslations()` to work; `setRequestLocale` is
+   required to keep all routes statically prerendered. This combination
+   was reintroduced in PR #9 (after a previous Amplify regression on Next 14
+   in commit `5719a20` had stripped it) and Amplify-smoked successfully on
+   Next 15.2.4 + React 19. **If you change anything in this region, smoke-
+   test on an Amplify deploy preview before merging to main.** See gotcha
+   `amplify-client-component-quirk`.
+3. **No env-var usage in any Client Component**. Only `NEXT_PUBLIC_*` vars
    reach the browser, and no such vars exist today. See gotcha
    `client-component-env-vars`.
 
+(The previously load-bearing `serverExternalPackages: ['next-intl']` entry
+was removed in PR #9 — it was redundant with `createNextIntlPlugin` and
+prevented `useTranslations()` from resolving the `react-server` export at
+SSG time. Build is green and Amplify deploy verified without it.)
+
 ## 7. Dead dependencies
 
-**Status as of 2026-04-24**: clean in the working tree, pending commit.
+**Status as of 2026-04-25**: clean. Two waves of removal landed:
 
-The 2026-04 editorial redesign orphaned five deps. They were uninstalled in a
-single `pnpm remove` call this session but not yet committed:
+- **PR #6** — orphaned by the 2026-04 editorial redesign:
+  `three`, `@react-three/fiber`, `@react-three/drei` (old `HeroBackground`),
+  `framer-motion` (old page animations, replaced by CSS +
+  `IntersectionObserver`), `react-parallax-tilt` (old `Tilt` app cards),
+  `@types/three` (devDep).
+- **PR #11** — orphaned when the shadcn scaffold was deleted in PR #7:
+  `next-themes`, `sonner`. Both were only consumed by
+  `components/ui/sonner.tsx`.
 
-- `three`, `@react-three/fiber`, `@react-three/drei` — old `HeroBackground`
-  (file deleted).
-- `framer-motion` — old page animations (replaced by CSS + `IntersectionObserver`).
-- `react-parallax-tilt` — old `Tilt` app cards (replaced by the editorial vitrine).
-- `@types/three` (devDep).
-
-The removal is **its own dedicated PR** — never a drive-by in unrelated work.
-See gotcha `dead-deps-removal-dedicated-pr` for the verification checklist.
-
-`next-themes` stays — it's a peer of `components/ui/sonner.tsx` (scaffold,
-unused at runtime but tsc references it).
+Both followed gotcha `dead-deps-removal-dedicated-pr` — each was its own
+PR, never bundled with feature work. **Going forward, any future dep
+removal must follow the same pattern.**
 
 ## 8. Directory structure
 
 ```
 app/
   globals.css                     # All styling. Layers: tailwind, global HSL,
-                                  #   legacy helpers, .ab-root, .sup-root
+                                  #   legacy helpers (.text-gradient, etc.),
+                                  #   .ab-root (incl. .ab-legal-* + .ab-prose),
+                                  #   .sup-root (data-app="fingo"|"savely")
   [locale]/
-    layout.tsx                    # Only layout. next/font Inter. Metadata.
-    page.tsx                      # Homepage (editorial redesign, ~930 lines).
-    not-found.tsx                 # Only file using useTranslations().
-    privacy/ · terms/ · privacy/choices/   # SimplePageLayout-based utility pages.
+    layout.tsx                    # Server Component. NextIntlClientProvider +
+                                  #   unstable_setRequestLocale. next/font Inter.
+                                  #   Metadata. Skip-link via getTranslations.
+    page.tsx                      # Homepage (Client). useTranslations('home').
+    not-found.tsx                 # 404. Client. useTranslations('notFound').
+                                  #   Still uses .text-gradient (legacy purple/orange).
+    privacy/ · terms/ · privacy/choices/
+                                  # Inline .ab-root shells, useTranslations('legal').
+                                  # Bilingual EN/ES.
     fingo/support/                # SupportShell, data-app="fingo"
     savely/support/               # SupportShell, data-app="savely"
 components/
-  simple-page-layout.tsx          # Legacy gray/gradient shell for utility pages
-  support-shell.tsx               # New reusable support shell (ab-root cousin)
-  ui/                             # shadcn scaffold (50 components, mostly unused)
+  support-shell.tsx               # Reusable support shell. data-app union is
+                                  #   "fingo" | "savely" only.
 messages/
-  en.json · es.json               # next-intl dictionaries (only notFound used today)
-lib/
-  utils.ts                        # cn() helper
+  en.json · es.json               # next-intl dictionaries.
+                                  # Top-level: notFound, layout, legal, home.
 public/                           # All static assets, logos, hero images
-i18n.ts                           # next-intl config
-middleware.ts                     # next-intl middleware
+i18n.ts                           # next-intl config (createNextIntlPlugin)
+middleware.ts                     # next-intl middleware (locale routing)
 next.config.mjs · tailwind.config.ts · tsconfig.json
 .claude/                          # Claude Code harness (see section 10)
 ```
+
+(No `components/ui/`, no `hooks/`, no `lib/` today — all removed in PR #7
+along with the shadcn scaffold.)
 
 ## 9. Git discipline
 
@@ -219,7 +260,7 @@ Specialists in `.claude/agents/`:
 
 | Agent | Owns |
 |-------|------|
-| `frontend-ui-specialist` | `app/**/*.tsx`, `components/**/*.tsx`, `globals.css`, Tailwind, shadcn, tokens |
+| `frontend-ui-specialist` | `app/**/*.tsx`, `components/**/*.tsx`, `globals.css`, Tailwind, design tokens |
 | `content-i18n-specialist` | EN/ES copy, `messages/*.json`, middleware routing |
 | `infra-deploy-specialist` | `next.config.mjs`, package.json scripts, deps, Amplify config |
 | `spec-writer` | Feature/refactor planner (read-only on source, writes under `docs/` or `.claude/knowledge/`) |


### PR DESCRIPTION
## Summary

Brings every Claude Code reference doc in sync with the post-cleanup
state of the codebase. Follow-up to the 6-PR legacy-removal pass:
PR #7 (shadcn sweep), PR #8 (lorenzana theme drop), PR #9 (i18n
canonical), PR #11 (orphaned deps), PR #12 (legal-page rewrite),
PR #13 (placeholder fill).

No source-code changes. Touches only:
- `CLAUDE.md`
- `.claude/knowledge/gotchas.yaml`
- `.claude/agents/{frontend-ui,infra-deploy,content-i18n}-specialist.md`

## Notable rule changes
- **i18n-pattern-canonical**: now a no-`isSpanish` rule (migration is
  done, never reintroduce).
- **amplify-client-component-quirk**: rewritten. The provider is back,
  was Amplify-smoked successfully on Next 15.2.4 + React 19, and the
  forward-looking rule is to smoke any future change to the i18n
  provider wiring.
- **dead-deps-removal-dedicated-pr**: history covers both 2026-04
  waves; verification checklist updated (lib/, hooks/ no longer exist).

## Gotchas honored

This PR touches only documentation files. No gotcha triggers fire on
doc-only diffs. The changes document gotcha compliance rather than
introducing new code paths.

## Test plan
- [x] No source code touched — build behavior unchanged.
- [ ] Reviewer: skim CLAUDE.md sections 5 + 6 to confirm the i18n /
      Amplify story matches your understanding.
- [ ] Reviewer: spot-check gotchas.yaml entries to confirm the rules
      match the current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)