### PR TITLE
Redesign 404 page with editorial .ab-root shell

### DIFF
--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,46 +1,148 @@
 "use client"
 
-import type React from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
-import { AlertTriangleIcon, HomeIcon } from "lucide-react"
+import { useParams, useRouter } from "next/navigation"
 import { useTranslations } from "next-intl"
 
-const GradientButton = ({
-  href,
-  children,
-  className,
-}: { href: string; children: React.ReactNode; className?: string }) => (
-  <Link
-    href={href}
-    className={`inline-flex items-center justify-center px-6 py-3 rounded-full text-white font-semibold bg-gradient-to-r from-orange-500 via-pink-500 to-purple-600 hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 ease-in-out shadow-lg ${className}`}
-  >
-    {children}
-  </Link>
-)
+type Theme = "light" | "dark"
+type Lang = "en" | "es"
+
+const LANGUAGE_COOKIE = "preferred-language"
 
 export default function NotFound() {
+  const params = useParams()
+  const router = useRouter()
+  const locale = (((params?.locale as string) || "en") === "es" ? "es" : "en") as Lang
   const t = useTranslations("notFound")
 
+  const [theme, setTheme] = useState<Theme>("light")
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    let initial: Theme
+    try {
+      const saved = localStorage.getItem("ab_theme") as Theme | null
+      if (saved === "light" || saved === "dark") initial = saved
+      else initial = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    } catch {
+      initial = "light"
+    }
+    setTheme(initial)
+    setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    try {
+      localStorage.setItem("ab_theme", theme)
+    } catch {}
+  }, [theme, hydrated])
+
+  const toggleTheme = () => setTheme((p) => (p === "dark" ? "light" : "dark"))
+
+  const switchLocale = () => {
+    const target: Lang = locale === "es" ? "en" : "es"
+    const expires = new Date()
+    expires.setFullYear(expires.getFullYear() + 1)
+    document.cookie = `${LANGUAGE_COOKIE}=${target}; expires=${expires.toUTCString()}; path=/`
+    router.push(`/${target}`)
+  }
+
+  const themeLabel = theme === "dark" ? t("themeToggleLight") : t("themeToggleDark")
+
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center justify-center text-center p-6">
-      <div className="max-w-md w-full">
-        <AlertTriangleIcon className="mx-auto h-20 w-20 text-pink-500 mb-6" />
+    <div className="ab-root ab-nf-root" data-theme={theme}>
+      <nav className="ab-nf-nav" aria-label="Atelier Belli">
+        <Link href={`/${locale}`} className="ab-nf-mark" aria-label="Atelier Belli — Home">
+          <svg
+            viewBox="0 0 418 439"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            className="ab-nf-mark-svg"
+          >
+            <path
+              fill="currentColor"
+              d="M309.858 65.3296L381.867 107.607L403.76 120.585C407.627 122.898 413.235 126.427 417.139 128.423C404.352 135.354 391.264 143.371 378.71 150.721L322.099 183.565C322.645 201.011 322.184 220.827 322.177 238.447L322.167 268.865C322.167 273.91 322.184 278.981 322.148 284.029C322.141 285.262 322.171 285.432 321.529 286.139C306.959 278.65 290.56 268.254 276.203 259.839C255.75 247.856 234.721 236.232 214.461 224.059C213.92 211.665 214.179 197.915 214.182 185.42L214.197 122.791C221.054 118.226 230.434 112.869 237.637 108.572L282.754 81.6101C291.49 76.4108 301.433 70.8473 309.858 65.3296Z"
+            />
+            <path
+              fill="#56B3C2"
+              d="M176.404 0C179.141 0.852222 197.867 12.5246 201.139 14.4668L268.828 54.3989L151.589 124.157L117.037 144.624C110.186 148.708 101.165 154.448 94.1272 157.877L94.1102 308.139L94.0929 351.974C94.0886 359.243 94.3 367.916 94.0124 375.097L93.5173 375.293C77.1485 366.643 57.9991 354.51 41.7095 344.901L17.4601 330.556C12.0696 327.373 5.05491 323.385 0.130637 319.766C-0.126537 311.512 0.0743604 302.176 0.0799227 293.84L0.107072 246.796L0.140772 104.191L176.404 0Z"
+            />
+          </svg>
+          <span className="ab-nf-name">
+            Atelier <em>Belli</em>
+          </span>
+        </Link>
 
-        <h1 className="text-6xl sm:text-7xl font-bold mb-4">
-          <span className="text-gradient">404</span>
-        </h1>
+        <div className="ab-nf-controls" role="group" aria-label="Site controls">
+          <button
+            type="button"
+            className={`ab-nf-ctrl${locale === "en" ? " is-active" : ""}`}
+            aria-pressed={locale === "en"}
+            aria-label={t("localeSwitchAria")}
+            onClick={switchLocale}
+          >
+            EN
+          </button>
+          <button
+            type="button"
+            className={`ab-nf-ctrl${locale === "es" ? " is-active" : ""}`}
+            aria-pressed={locale === "es"}
+            aria-label={t("localeSwitchAria")}
+            onClick={switchLocale}
+          >
+            ES
+          </button>
+          <span className="ab-nf-ctrl-sep" aria-hidden="true" />
+          <button
+            type="button"
+            className="ab-nf-ctrl"
+            onClick={toggleTheme}
+            aria-label={t("themeToggleAria")}
+          >
+            {themeLabel}
+          </button>
+        </div>
+      </nav>
 
-        <h2 className="text-2xl sm:text-3xl font-semibold text-white mb-3">{t("title")}</h2>
+      <main className="ab-nf-main">
+        <div className="ab-nf-stage">
+          <div className="ab-nf-eye">
+            <span className="ab-nf-eye-dot" aria-hidden="true" />
+            <span>{t("eye")}</span>
+          </div>
 
-        <p className="text-gray-400 mb-8 text-base sm:text-lg">{t("description")}</p>
+          <h1 className="ab-nf-display" aria-label="404">
+            <span aria-hidden="true">4</span>
+            <span aria-hidden="true" className="ab-nf-it">
+              0
+            </span>
+            <span aria-hidden="true">4</span>
+          </h1>
 
-        <GradientButton href="/">
-          <HomeIcon className="mr-2 h-5 w-5" />
-          {t("backHome")}
-        </GradientButton>
-      </div>
-      <footer className="absolute bottom-8 text-center w-full text-gray-500 text-sm">
-        <p>&copy; {new Date().getFullYear()} Atelier Belli</p>
+          <h2 className="ab-nf-title">
+            {t("titlePre")}
+            <em>{t("titleIt")}</em>
+          </h2>
+
+          <p className="ab-nf-desc">{t("description")}</p>
+
+          <Link href={`/${locale}`} className="ab-nf-cta">
+            <span>{t("backHome")}</span>
+            <span className="ab-nf-cta-arrow" aria-hidden="true">
+              →
+            </span>
+          </Link>
+        </div>
+      </main>
+
+      <footer className="ab-nf-foot">
+        <span className="ab-nf-copy">© {new Date().getFullYear()} Atelier Belli</span>
+        <span className="ab-nf-meta">
+          <em>Tijuana</em> — {t("footerMeta")}
+        </span>
       </footer>
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -86,11 +86,6 @@
   }
 }
 
-/* Legacy helpers — still used by /privacy, /terms, /fingo/support, /savely/support sub-pages */
-.text-gradient {
-  @apply bg-gradient-to-r from-orange-500 via-pink-500 to-purple-600 bg-clip-text text-transparent;
-}
-
 /* Skip-to-content link for keyboard / screen-reader users */
 .skip-link {
   position: absolute;
@@ -2015,6 +2010,233 @@
 }
 .ab-legal-foot-nav a:hover {
   color: var(--ab-fg);
+}
+
+/* ──────────────────────────────────────────────────────────────────────
+   404 / not-found — editorial shell scoped under .ab-root
+   Mirrors the homepage chrome + Fraunces display anchor with italic
+   accent on the centre "0".
+   ────────────────────────────────────────────────────────────────────── */
+.ab-nf-root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.ab-nf-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 22px clamp(20px, 5vw, 56px);
+  border-bottom: 1px solid var(--line-2);
+}
+.ab-nf-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--ab-fg);
+}
+.ab-nf-mark-svg {
+  width: 22px;
+  height: 23px;
+  display: block;
+}
+.ab-nf-name {
+  font-family: var(--ab-serif);
+  font-weight: 500;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.ab-nf-name em {
+  font-style: italic;
+  color: var(--accent-color);
+  font-weight: 400;
+}
+.ab-nf-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ab-nf-ctrl {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--ab-muted);
+  font: 500 11px/1 var(--ab-sans);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: color var(--ab-trans);
+}
+.ab-nf-ctrl:hover {
+  color: var(--ab-fg);
+}
+.ab-nf-ctrl.is-active {
+  color: var(--ab-fg);
+}
+.ab-nf-ctrl-sep {
+  width: 1px;
+  height: 12px;
+  background: var(--line);
+  margin: 0 6px;
+  display: inline-block;
+}
+.ab-nf-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(40px, 8vh, 96px) clamp(20px, 5vw, 56px);
+}
+.ab-nf-stage {
+  width: 100%;
+  max-width: 760px;
+  text-align: center;
+  animation: ab-nf-fade-up 0.6s ease both;
+}
+@keyframes ab-nf-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ab-nf-stage {
+    animation: none;
+  }
+}
+.ab-nf-eye {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font: 500 11px/1 var(--ab-sans);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ab-muted);
+  margin-bottom: clamp(28px, 6vh, 48px);
+}
+.ab-nf-eye-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent-color);
+  display: inline-block;
+}
+.ab-nf-display {
+  font-family: var(--ab-serif);
+  font-variation-settings: "opsz" 144, "SOFT" 50;
+  font-weight: 400;
+  font-size: clamp(140px, 26vw, 280px);
+  line-height: 0.92;
+  letter-spacing: -0.04em;
+  color: var(--ab-fg);
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+}
+.ab-nf-display .ab-nf-it {
+  font-style: italic;
+  color: var(--accent-color);
+  font-variation-settings: "opsz" 144, "SOFT" 100;
+}
+.ab-nf-title {
+  font-family: var(--ab-serif);
+  font-variation-settings: "opsz" 36;
+  font-weight: 400;
+  font-size: clamp(26px, 3.6vw, 36px);
+  line-height: 1.18;
+  letter-spacing: -0.015em;
+  margin: clamp(28px, 5vh, 40px) 0 14px;
+}
+.ab-nf-title em {
+  font-style: italic;
+  color: var(--accent-color);
+  font-weight: 400;
+}
+.ab-nf-desc {
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: var(--ab-muted);
+  max-width: 46ch;
+  margin: 0 auto clamp(36px, 6vh, 56px);
+  text-wrap: pretty;
+}
+.ab-nf-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 22px 14px 24px;
+  border-radius: 999px;
+  background: var(--accent-color);
+  color: var(--ab-bg);
+  text-decoration: none;
+  font: 500 11px/1 var(--ab-sans);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  border: 1px solid var(--accent-color);
+  transition:
+    background-color var(--ab-trans),
+    border-color var(--ab-trans),
+    transform var(--ab-trans);
+  white-space: nowrap;
+}
+.ab-nf-cta:hover {
+  background: var(--accent-deep);
+  border-color: var(--accent-deep);
+  transform: translateY(-1px);
+}
+.ab-nf-cta-arrow {
+  display: inline-block;
+  transition: transform 0.25s ease;
+}
+.ab-nf-cta:hover .ab-nf-cta-arrow {
+  transform: translateX(3px);
+}
+.ab-nf-foot {
+  padding: 22px clamp(20px, 5vw, 56px);
+  border-top: 1px solid var(--line-2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.ab-nf-copy,
+.ab-nf-meta {
+  font: 500 11px/1 var(--ab-sans);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ab-muted);
+}
+.ab-nf-meta em {
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--ab-muted);
+}
+@media (max-width: 540px) {
+  .ab-nf-display {
+    font-size: clamp(120px, 38vw, 200px);
+  }
+  .ab-nf-title {
+    font-size: 24px;
+  }
+  .ab-nf-desc {
+    font-size: 14.5px;
+  }
+  .ab-nf-foot {
+    flex-direction: column;
+    gap: 10px;
+    text-align: center;
+  }
+  .ab-nf-ctrl {
+    padding: 8px 8px;
+  }
 }
 
 /* ──────────────────────────────────────────────────────────────────────

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,8 +1,15 @@
 {
   "notFound": {
-    "title": "Page Not Found",
+    "eye": "Lost · Error 404",
+    "titlePre": "Page not ",
+    "titleIt": "found.",
     "description": "Sorry, the page you're looking for doesn't exist or has been moved.",
-    "backHome": "Back to Home"
+    "backHome": "Back to Home",
+    "themeToggleLight": "Light",
+    "themeToggleDark": "Dark",
+    "themeToggleAria": "Toggle theme",
+    "localeSwitchAria": "Cambiar a Español",
+    "footerMeta": "Software · Digital craft"
   },
   "layout": {
     "skipToContent": "Skip to main content"

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,8 +1,15 @@
 {
   "notFound": {
-    "title": "Página No Encontrada",
+    "eye": "Perdido · Error 404",
+    "titlePre": "Página no ",
+    "titleIt": "encontrada.",
     "description": "Lo sentimos, la página que estás buscando no existe o ha sido movida.",
-    "backHome": "Volver al Inicio"
+    "backHome": "Volver al Inicio",
+    "themeToggleLight": "Claro",
+    "themeToggleDark": "Oscuro",
+    "themeToggleAria": "Cambiar tema",
+    "localeSwitchAria": "Switch to English",
+    "footerMeta": "Software · Oficio digital"
   },
   "layout": {
     "skipToContent": "Ir al contenido principal"


### PR DESCRIPTION
## Summary

Implements the Claude Design 404 prototype shipped via the design
handoff bundle. Replaces the legacy purple/orange/pink gradient page
with a calm editorial layout consistent with the rest of the site.

- **Visual anchor**: large Fraunces "404" with the centre "0" italic
  in accent turquoise (the signature italic-on-serif pattern used on
  the homepage hero).
- **Title**: `Page not <em>found.</em>` / `Página no <em>encontrada.</em>`.
- **Chrome**: top nav (Atelier Belli inline SVG mark + EN/ES locale
  toggle + theme toggle), single pill CTA back to `/`, hairline
  footer with `Tijuana — Software · Digital craft`.
- **Theming**: light + dark via `data-theme` on the wrapping
  `.ab-root` div; persisted in `localStorage` (`ab_theme`); locale
  swap mirrors the homepage's cookie + `router.push` pattern.
- **Tokens only**: `--ab-bg`, `--ab-fg`, `--ab-muted`, `--accent-color`,
  `--accent-deep`, `--line`, `--line-2`. No new tokens. No images, no
  icons, no gradients.

## Drops
- `.text-gradient` rule from `app/globals.css` (now zero consumers).
- The `AlertTriangleIcon` / `HomeIcon` imports + the `GradientButton`
  helper from the old `not-found.tsx`.

## Side-effect (follow-up PR, not bundled here)
The above drops make `lucide-react` an orphan dependency. Per gotcha
`dead-deps-removal-dedicated-pr`, the `pnpm remove lucide-react` step
ships in a separate dedicated PR after this one merges.

## Gotchas honored
- `i18n-pattern-canonical` — `useTranslations("notFound")`, no isSpanish.
- `root-token-scoping` — every new style scoped under `.ab-root`.
- `amplify-client-component-quirk` — no provider wiring touched.

## Test plan
- [x] `pnpm exec tsc --noEmit` — green.
- [x] `pnpm build` — green, all 15 SSG routes generate.
- [ ] Visual smoke: navigate to `/en/this-does-not-exist` and
      `/es/this-does-not-exist`. Verify light + dark themes render,
      locale toggle navigates to `/en` / `/es`, theme toggle persists,
      CTA returns to `/${locale}`, fade-up animates once.
- [ ] Lighthouse / a11y spot-check (focus rings, contrast on the
      italic accent on both themes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)