### PR TITLE
Fix not-found rendering: catch-all route + server-component shell

### DIFF
--- a/app/[locale]/[...rest]/page.tsx
+++ b/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,12 @@
+import { notFound } from "next/navigation"
+import { unstable_setRequestLocale } from "next-intl/server"
+
+export default async function CatchAllNotFound({
+  params,
+}: {
+  params: Promise<{ locale: string; rest: string[] }>
+}) {
+  const { locale } = await params
+  unstable_setRequestLocale(locale)
+  notFound()
+}

--- a/app/[locale]/_not-found-controls.tsx
+++ b/app/[locale]/_not-found-controls.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+
+const LANGUAGE_COOKIE = "preferred-language"
+
+type Theme = "light" | "dark"
+
+export function NotFoundControls({
+  locale,
+  otherLocale,
+  themeLightLabel,
+  themeDarkLabel,
+  themeAriaLabel,
+  localeAriaLabel,
+}: {
+  locale: "en" | "es"
+  otherLocale: "en" | "es"
+  themeLightLabel: string
+  themeDarkLabel: string
+  themeAriaLabel: string
+  localeAriaLabel: string
+}) {
+  const router = useRouter()
+  const [theme, setTheme] = useState<Theme | null>(null)
+
+  useEffect(() => {
+    let initial: Theme
+    try {
+      const saved = localStorage.getItem("ab_theme") as Theme | null
+      if (saved === "light" || saved === "dark") initial = saved
+      else initial = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    } catch {
+      initial = "light"
+    }
+    setTheme(initial)
+  }, [])
+
+  useEffect(() => {
+    if (theme === null) return
+    const root = document.querySelector<HTMLElement>(".ab-nf-root.ab-root")
+    if (root) root.setAttribute("data-theme", theme)
+    try {
+      localStorage.setItem("ab_theme", theme)
+    } catch {}
+  }, [theme])
+
+  const toggleTheme = () => setTheme((p) => (p === "dark" ? "light" : "dark"))
+
+  const switchLocale = () => {
+    const expires = new Date()
+    expires.setFullYear(expires.getFullYear() + 1)
+    document.cookie = `${LANGUAGE_COOKIE}=${otherLocale}; expires=${expires.toUTCString()}; path=/`
+    router.push(`/${otherLocale}`)
+  }
+
+  const themeLabel = theme === "dark" ? themeLightLabel : themeDarkLabel
+
+  return (
+    <div className="ab-nf-controls" role="group" aria-label="Site controls">
+      <button
+        type="button"
+        className={`ab-nf-ctrl${locale === "en" ? " is-active" : ""}`}
+        aria-pressed={locale === "en"}
+        aria-label={localeAriaLabel}
+        onClick={switchLocale}
+      >
+        EN
+      </button>
+      <button
+        type="button"
+        className={`ab-nf-ctrl${locale === "es" ? " is-active" : ""}`}
+        aria-pressed={locale === "es"}
+        aria-label={localeAriaLabel}
+        onClick={switchLocale}
+      >
+        ES
+      </button>
+      <span className="ab-nf-ctrl-sep" aria-hidden="true" />
+      <button
+        type="button"
+        className="ab-nf-ctrl"
+        onClick={toggleTheme}
+        aria-label={themeAriaLabel}
+        suppressHydrationWarning
+      >
+        {themeLabel}
+      </button>
+    </div>
+  )
+}

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,58 +1,18 @@
-"use client"
-
-import { useEffect, useState } from "react"
 import Link from "next/link"
-import { useParams, useRouter } from "next/navigation"
-import { useTranslations } from "next-intl"
+import { getLocale, getTranslations } from "next-intl/server"
+import { NotFoundControls } from "./_not-found-controls"
 
-type Theme = "light" | "dark"
-type Lang = "en" | "es"
+const THEME_INIT_SCRIPT = `(function(){try{var t=localStorage.getItem("ab_theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}var r=document.currentScript&&document.currentScript.parentElement;if(r&&r.classList.contains("ab-root")){r.setAttribute("data-theme",t);}}catch(e){}})();`
 
-const LANGUAGE_COOKIE = "preferred-language"
-
-export default function NotFound() {
-  const params = useParams()
-  const router = useRouter()
-  const locale = (((params?.locale as string) || "en") === "es" ? "es" : "en") as Lang
-  const t = useTranslations("notFound")
-
-  const [theme, setTheme] = useState<Theme>("light")
-  const [hydrated, setHydrated] = useState(false)
-
-  useEffect(() => {
-    let initial: Theme
-    try {
-      const saved = localStorage.getItem("ab_theme") as Theme | null
-      if (saved === "light" || saved === "dark") initial = saved
-      else initial = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
-    } catch {
-      initial = "light"
-    }
-    setTheme(initial)
-    setHydrated(true)
-  }, [])
-
-  useEffect(() => {
-    if (!hydrated) return
-    try {
-      localStorage.setItem("ab_theme", theme)
-    } catch {}
-  }, [theme, hydrated])
-
-  const toggleTheme = () => setTheme((p) => (p === "dark" ? "light" : "dark"))
-
-  const switchLocale = () => {
-    const target: Lang = locale === "es" ? "en" : "es"
-    const expires = new Date()
-    expires.setFullYear(expires.getFullYear() + 1)
-    document.cookie = `${LANGUAGE_COOKIE}=${target}; expires=${expires.toUTCString()}; path=/`
-    router.push(`/${target}`)
-  }
-
-  const themeLabel = theme === "dark" ? t("themeToggleLight") : t("themeToggleDark")
+export default async function NotFound() {
+  const locale = (await getLocale()) === "es" ? "es" : "en"
+  const t = await getTranslations("notFound")
+  const otherLocale = locale === "es" ? "en" : "es"
+  const year = new Date().getFullYear()
 
   return (
-    <div className="ab-root ab-nf-root" data-theme={theme}>
+    <div className="ab-root ab-nf-root" data-theme="light">
+      <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
       <nav className="ab-nf-nav" aria-label="Atelier Belli">
         <Link href={`/${locale}`} className="ab-nf-mark" aria-label="Atelier Belli — Home">
           <svg
@@ -76,35 +36,14 @@ export default function NotFound() {
           </span>
         </Link>
 
-        <div className="ab-nf-controls" role="group" aria-label="Site controls">
-          <button
-            type="button"
-            className={`ab-nf-ctrl${locale === "en" ? " is-active" : ""}`}
-            aria-pressed={locale === "en"}
-            aria-label={t("localeSwitchAria")}
-            onClick={switchLocale}
-          >
-            EN
-          </button>
-          <button
-            type="button"
-            className={`ab-nf-ctrl${locale === "es" ? " is-active" : ""}`}
-            aria-pressed={locale === "es"}
-            aria-label={t("localeSwitchAria")}
-            onClick={switchLocale}
-          >
-            ES
-          </button>
-          <span className="ab-nf-ctrl-sep" aria-hidden="true" />
-          <button
-            type="button"
-            className="ab-nf-ctrl"
-            onClick={toggleTheme}
-            aria-label={t("themeToggleAria")}
-          >
-            {themeLabel}
-          </button>
-        </div>
+        <NotFoundControls
+          locale={locale}
+          otherLocale={otherLocale}
+          themeLightLabel={t("themeToggleLight")}
+          themeDarkLabel={t("themeToggleDark")}
+          themeAriaLabel={t("themeToggleAria")}
+          localeAriaLabel={t("localeSwitchAria")}
+        />
       </nav>
 
       <main className="ab-nf-main">
@@ -139,7 +78,7 @@ export default function NotFound() {
       </main>
 
       <footer className="ab-nf-foot">
-        <span className="ab-nf-copy">© {new Date().getFullYear()} Atelier Belli</span>
+        <span className="ab-nf-copy">© {year} Atelier Belli</span>
         <span className="ab-nf-meta">
           <em>Tijuana</em> — {t("footerMeta")}
         </span>


### PR DESCRIPTION
## Summary

Follow-up to #17. Two bugs surfaced after the editorial 404 redesign merged:

1. **`app/[locale]/not-found.tsx` never fires for invalid URLs.** Next 15
   App Router only renders the segment-level not-found when something
   calls `notFound()` programmatically. Visiting `/en/anything-bad`
   falls through to Next's global default 404 — which is what was
   shipping after #17 merged. Pre-existing bug; the legacy
   purple/orange not-found never ran for invalid URLs either.
2. **Server-thrown `notFound()` → Client `not-found.tsx` falls back to
   the default 404 in Next 15.2.4.** The Flight payload showed
   `"isNotFoundPath":false` and the custom tree was registered but
   never rendered.

## Fix (3 files)

- **`app/[locale]/[...rest]/page.tsx`** (new) — Server catch-all that
  awaits `params`, calls `unstable_setRequestLocale(locale)`, then
  `notFound()`. Intercepts every unmatched URL inside the locale
  segment and surfaces the closest `not-found.tsx`.
- **`app/[locale]/not-found.tsx`** — converted to a Server Component
  using `getLocale()` + `getTranslations("notFound")`. Static markup
  renders server-side. This is the variant Next 15.2.4 renders cleanly
  from a server-thrown `notFound()`.
- **`app/[locale]/_not-found-controls.tsx`** (new, `"use client"`) —
  isolated island for the EN/ES + theme buttons. Reads/writes
  `localStorage.ab_theme` and updates the wrapping `.ab-nf-root`
  `data-theme` attribute imperatively. Inline `<script>` seeds the
  theme before hydration to avoid flash.

## Verification (this time I ran `pnpm dev` and curl-checked)

```
/en/fsasdasd  → HTTP 404, 62 KB, ab-nf-root + ab-nf-display in tree, "Page not found." resolves
/es/no-existe → HTTP 404, 64 KB, ab-nf-root + ab-nf-display in tree, "Página no encontrada." resolves
```

`pnpm exec tsc --noEmit` exits 0; `pnpm build` exits 0. Build legend
gains `ƒ (Dynamic) server-rendered on demand` because the catch-all is
per-request.

## Gotchas honored
- `i18n-pattern-canonical` — `getLocale` + `getTranslations` server-side, `useEffect` only for the theme island.
- `root-token-scoping` — no new tokens; `.ab-nf-*` still under `.ab-root`.
- `amplify-client-component-quirk` — provider untouched.

## Amplify smoke required before merge to main

The catch-all introduces a dynamic route. The site has been pure SSG
until now (CLAUDE.md §6 calls Amplify's runtime "static export model").
On the deploy preview, hit `/en/<bad-url>/` and `/es/<bad-url>/` and
confirm the editorial 404 renders — not Amplify's own fallback. If
Amplify needs configuration changes for the new `ƒ` route, it'll
surface here.

## Test plan
- [x] Local `pnpm dev` curl on EN + ES bad URLs — both render the new shell.
- [x] `pnpm exec tsc --noEmit` — green.
- [x] `pnpm build` — green; all SSG routes intact, catch-all listed as dynamic.
- [ ] Visual smoke on `/en/anything-bad` and `/es/anything-bad` in the browser; theme toggle persists; locale toggle navigates to `/${other}`.
- [ ] **Amplify deploy preview smoke** before merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)