### PR TITLE
Remove orphaned lucide-react dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "date-fns": "2.30.0",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
-    "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-intl": "3.19.1",
     "react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      lucide-react:
-        specifier: ^0.454.0
-        version: 0.454.0(react@19.1.0)
       next:
         specifier: 15.2.4
         version: 15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1455,11 +1452,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lucide-react@0.454.0:
-    resolution: {integrity: sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3157,10 +3149,6 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
-
-  lucide-react@0.454.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
 
   merge2@1.4.1: {}
 


### PR DESCRIPTION
## Summary

Removes `lucide-react` from `package.json`. It became orphaned when
PR #17 redesigned the 404 page and PR #18 split it into a server
shell + client controls island — neither file imports any icon
library. No source code touched here.

## Gotchas honored
- `dead-deps-removal-dedicated-pr` — dedicated removal PR, no other source-code changes.
- `pnpm-is-package-manager` — used `pnpm remove`, not npm/yarn.

## Test plan
- [x] `grep -rEn "from ['\"]lucide-react" app components` — zero matches.
- [x] `pnpm exec tsc --noEmit` — green.
- [x] `pnpm build` — green; all SSG routes + the [...rest] catch-all generate.
- [ ] Visual smoke `/en` and `/es` after merge — confirm no missing icons anywhere on the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)