### PR TITLE
Migrate Fingo support page to next-intl

### DIFF
--- a/app/[locale]/fingo/support/page.tsx
+++ b/app/[locale]/fingo/support/page.tsx
@@ -1,201 +1,65 @@
 "use client"
 
+import { useMemo } from "react"
 import { useParams } from "next/navigation"
+import { useTranslations } from "next-intl"
 import SupportShell, { type SupportContent } from "@/components/support-shell"
 
-type Lang = "en" | "es"
-
-const CONTENT: Record<Lang, SupportContent> = {
-  en: {
-    name: "Fingo",
-    crest: "F",
-    navLabel: "Fingo · Support",
-    footMeta: "Fingo — Support desk · 2025",
-
-    heroEye: "Support · v2.1.0",
-    heroTitle: "How can we <em>help?</em>",
-    heroLede:
-      "Fingo is a tiny app for deciding who pays, who goes first, who picks the music. If something doesn't work the way it should — write to us. A real person reads every message.",
-
-    contactTitle: "Get in <em>touch.</em>",
-    contactSub: "Choose what suits you best. Everything routes to the same desk.",
-    contacts: [
-      {
-        kind: "email",
-        label: "Email",
-        value: "ivanlorenzana@outlook.com",
-        hint: "Replies within 24h, usually sooner.",
-        href: "mailto:ivanlorenzana@outlook.com",
-      },
-      {
-        kind: "bug",
-        label: "Report a bug",
-        value: "<em>Something</em> broken?",
-        hint: "A short note + screenshot goes a long way.",
-        href: "mailto:ivanlorenzana@outlook.com?subject=Fingo%20bug%20report",
-      },
-      {
-        kind: "feature",
-        label: "Request a feature",
-        value: "Imagine <em>better.</em>",
-        hint: "We read all of them. Some ship.",
-        href: "mailto:ivanlorenzana@outlook.com?subject=Fingo%20wishlist",
-      },
-      {
-        kind: "docs",
-        label: "Help centre",
-        value: "Guides &amp; tips",
-        hint: "Quick guides for the most common flows.",
-        href: "#",
-      },
-    ],
-
-    faqTitle: "Questions <em>we hear.</em>",
-    faqSub: "The ones that come up most. If yours isn't here, just write.",
-    faq: [
-      {
-        q: "Does Fingo share my contacts or data?",
-        a: "No. Fingo doesn't ship your contacts, choices, or results anywhere. Everything lives on your device; there's no account and no server to leak. If you delete the app, nothing stays behind.",
-      },
-      {
-        q: "Why do I need to enable haptics?",
-        a: "Because half of Fingo's joy is the click. You can turn them off in <em>Settings → Feedback</em>, but we'd suggest trying a spin with them on at least once.",
-      },
-      {
-        q: "Can I use Fingo without an internet connection?",
-        a: "Yes — completely. Fingo is fully offline. The only time the internet is touched is if you share a result as a card via Messages or Mail.",
-      },
-      {
-        q: "Where do I restore a purchase?",
-        a: "Settings → About → Restore Purchases. You'll need to be signed into the same Apple ID you used when buying. If it still doesn't work, <a href='mailto:ivanlorenzana@outlook.com'>email us</a>.",
-      },
-      {
-        q: "Is there an Android version?",
-        a: "Not yet. Fingo is SwiftUI-native and we want to keep the animation and haptic quality at the standard it is. An Android port is on the table but not promised.",
-      },
-    ],
-
-    statusTitle: "Everything <em>running.</em>",
-    statusSub: "Current version, platform, and how quickly we get back.",
-    status: [
-      { k: "Version", v: "2.1.0" },
-      { k: "Platform", v: "iOS 26+" },
-      { k: "Reply time", v: "~ 18 hours" },
-      { k: "Systems", v: "All good", ok: true },
-    ],
-
-    ctaTitle: "Still <em>stuck?</em>",
-    ctaSub: "Write to us directly.",
-    ctaLabel: "ivanlorenzana@outlook.com",
-    ctaHref: "mailto:ivanlorenzana@outlook.com",
-
-    sectionLabels: {
-      contact: "01 — Contact",
-      faq: "02 — Frequent questions",
-      status: "03 — Status",
-    },
-
-    privacyLabel: "Privacy",
-    termsLabel: "Terms",
-    backLabel: "Atelier Belli",
-  },
-  es: {
-    name: "Fingo",
-    crest: "F",
-    navLabel: "Fingo · Soporte",
-    footMeta: "Fingo — Mesa de soporte · 2025",
-
-    heroEye: "Soporte · v2.1.0",
-    heroTitle: "¿Cómo podemos <em>ayudar?</em>",
-    heroLede:
-      "Fingo es una pequeña app para decidir quién paga, quién empieza, quién escoge la música. Si algo no funciona como debería — escríbenos. Una persona real lee cada mensaje.",
-
-    contactTitle: "Estamos <em>aquí.</em>",
-    contactSub: "Elige el canal que mejor te funcione. Todo llega al mismo escritorio.",
-    contacts: [
-      {
-        kind: "email",
-        label: "Correo",
-        value: "ivanlorenzana@outlook.com",
-        hint: "Respondemos en 24h, normalmente antes.",
-        href: "mailto:ivanlorenzana@outlook.com",
-      },
-      {
-        kind: "bug",
-        label: "Reportar un error",
-        value: "¿<em>Algo</em> se rompió?",
-        hint: "Una nota breve y una captura ayudan mucho.",
-        href: "mailto:ivanlorenzana@outlook.com?subject=Fingo%20bug%20report",
-      },
-      {
-        kind: "feature",
-        label: "Sugerir función",
-        value: "Imagina <em>mejor.</em>",
-        hint: "Las leemos todas. Algunas se publican.",
-        href: "mailto:ivanlorenzana@outlook.com?subject=Fingo%20wishlist",
-      },
-      {
-        kind: "docs",
-        label: "Centro de ayuda",
-        value: "Guías y consejos",
-        hint: "Guías rápidas para los flujos más comunes.",
-        href: "#",
-      },
-    ],
-
-    faqTitle: "Preguntas <em>frecuentes.</em>",
-    faqSub: "Las que más nos llegan. Si la tuya no está, solo escribe.",
-    faq: [
-      {
-        q: "¿Fingo comparte mis contactos o datos?",
-        a: "No. Fingo no envía tus contactos, elecciones, ni resultados a ningún lado. Todo vive en tu dispositivo; no hay cuenta ni servidor que filtre nada. Si borras la app, no queda rastro.",
-      },
-      {
-        q: "¿Por qué necesito activar los háptics?",
-        a: "Porque la mitad de la gracia de Fingo es el click. Puedes apagarlos en <em>Ajustes → Feedback</em>, pero te sugerimos probar al menos un giro con ellos.",
-      },
-      {
-        q: "¿Puedo usar Fingo sin conexión a internet?",
-        a: "Sí — completamente. Fingo es totalmente offline. Lo único que toca internet es cuando compartes un resultado como tarjeta por Mensajes o Mail.",
-      },
-      {
-        q: "¿Dónde restauro una compra?",
-        a: "Ajustes → Acerca de → Restaurar compras. Necesitas estar con el mismo Apple ID con el que compraste. Si aún así no funciona, <a href='mailto:ivanlorenzana@outlook.com'>escríbenos</a>.",
-      },
-      {
-        q: "¿Hay versión para Android?",
-        a: "Aún no. Fingo es nativo en SwiftUI y queremos mantener la calidad de animación y háptics al nivel que está. Un puerto a Android está sobre la mesa, pero no prometido.",
-      },
-    ],
-
-    statusTitle: "Todo <em>funcionando.</em>",
-    statusSub: "Versión actual, plataforma, y cuán rápido respondemos.",
-    status: [
-      { k: "Versión", v: "2.1.0" },
-      { k: "Plataforma", v: "iOS 26+" },
-      { k: "Respuesta", v: "~ 18 horas" },
-      { k: "Sistemas", v: "Todo bien", ok: true },
-    ],
-
-    ctaTitle: "¿Sigues <em>atorado?</em>",
-    ctaSub: "Escríbenos directo.",
-    ctaLabel: "ivanlorenzana@outlook.com",
-    ctaHref: "mailto:ivanlorenzana@outlook.com",
-
-    sectionLabels: {
-      contact: "01 — Contacto",
-      faq: "02 — Preguntas frecuentes",
-      status: "03 — Estado",
-    },
-
-    privacyLabel: "Privacidad",
-    termsLabel: "Términos",
-    backLabel: "Atelier Belli",
-  },
-}
+const CONTACT_KINDS = ["email", "bug", "feature", "docs"] as const
 
 export default function FingoSupportPage() {
+  const t = useTranslations("support.fingo")
   const params = useParams()
-  const locale = (((params?.locale as string) || "en") === "es" ? "es" : "en") as Lang
-  return <SupportShell appKey="fingo" locale={locale} content={CONTENT[locale]} />
+  const locale = (params?.locale as string) === "es" ? "es" : "en"
+
+  const content = useMemo<SupportContent>(
+    () => ({
+      name: t("name"),
+      crest: t("crest"),
+      navLabel: t("navLabel"),
+      footMeta: t("footMeta"),
+
+      heroEye: t("hero.eye"),
+      heroTitle: t.raw("hero.titleHtml") as string,
+      heroLede: t("hero.lede"),
+
+      contactTitle: t.raw("contact.titleHtml") as string,
+      contactSub: t("contact.sub"),
+      contacts: CONTACT_KINDS.map((kind) => ({
+        kind,
+        label: t(`contact.cards.${kind}.label`),
+        value: t.raw(`contact.cards.${kind}.valueHtml`) as string,
+        hint: t(`contact.cards.${kind}.hint`),
+        href: t(`contact.cards.${kind}.href`),
+      })),
+
+      faqTitle: t.raw("faq.titleHtml") as string,
+      faqSub: t("faq.sub"),
+      faq: (t.raw("faq.items") as Array<{ q: string; aHtml: string }>).map(
+        ({ q, aHtml }) => ({ q, a: aHtml }),
+      ),
+
+      statusTitle: t.raw("status.titleHtml") as string,
+      statusSub: t("status.sub"),
+      status: t.raw("status.rows") as Array<{ k: string; v: string; ok?: boolean }>,
+
+      ctaTitle: t.raw("cta.titleHtml") as string,
+      ctaSub: t("cta.sub"),
+      ctaLabel: t("cta.label"),
+      ctaHref: t("cta.href"),
+
+      sectionLabels: {
+        contact: t("sectionLabels.contact"),
+        faq: t("sectionLabels.faq"),
+        status: t("sectionLabels.status"),
+      },
+
+      privacyLabel: t("privacyLabel"),
+      termsLabel: t("termsLabel"),
+      backLabel: t("backLabel"),
+    }),
+    [t],
+  )
+
+  return <SupportShell appKey="fingo" locale={locale} content={content} />
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -185,6 +185,106 @@
       }
     }
   },
+  "support": {
+    "fingo": {
+      "name": "Fingo",
+      "crest": "F",
+      "navLabel": "Fingo · Support",
+      "footMeta": "Fingo — Support desk · 2025",
+
+      "hero": {
+        "eye": "Support · v2.1.0",
+        "titleHtml": "How can we <em>help?</em>",
+        "lede": "Fingo is a tiny app for deciding who pays, who goes first, who picks the music. If something doesn't work the way it should — write to us. A real person reads every message."
+      },
+
+      "contact": {
+        "titleHtml": "Get in <em>touch.</em>",
+        "sub": "Choose what suits you best. Everything routes to the same desk.",
+        "cards": {
+          "email": {
+            "label": "Email",
+            "valueHtml": "ivanlorenzana@outlook.com",
+            "hint": "Replies within 24h, usually sooner.",
+            "href": "mailto:ivanlorenzana@outlook.com"
+          },
+          "bug": {
+            "label": "Report a bug",
+            "valueHtml": "<em>Something</em> broken?",
+            "hint": "A short note + screenshot goes a long way.",
+            "href": "mailto:ivanlorenzana@outlook.com?subject=Fingo%20bug%20report"
+          },
+          "feature": {
+            "label": "Request a feature",
+            "valueHtml": "Imagine <em>better.</em>",
+            "hint": "We read all of them. Some ship.",
+            "href": "mailto:ivanlorenzana@outlook.com?subject=Fingo%20wishlist"
+          },
+          "docs": {
+            "label": "Help centre",
+            "valueHtml": "Guides &amp; tips",
+            "hint": "Quick guides for the most common flows.",
+            "href": "#"
+          }
+        }
+      },
+
+      "faq": {
+        "titleHtml": "Questions <em>we hear.</em>",
+        "sub": "The ones that come up most. If yours isn't here, just write.",
+        "items": [
+          {
+            "q": "Does Fingo share my contacts or data?",
+            "aHtml": "No. Fingo doesn't ship your contacts, choices, or results anywhere. Everything lives on your device; there's no account and no server to leak. If you delete the app, nothing stays behind."
+          },
+          {
+            "q": "Why do I need to enable haptics?",
+            "aHtml": "Because half of Fingo's joy is the click. You can turn them off in <em>Settings → Feedback</em>, but we'd suggest trying a spin with them on at least once."
+          },
+          {
+            "q": "Can I use Fingo without an internet connection?",
+            "aHtml": "Yes — completely. Fingo is fully offline. The only time the internet is touched is if you share a result as a card via Messages or Mail."
+          },
+          {
+            "q": "Where do I restore a purchase?",
+            "aHtml": "Settings → About → Restore Purchases. You'll need to be signed into the same Apple ID you used when buying. If it still doesn't work, <a href='mailto:ivanlorenzana@outlook.com'>email us</a>."
+          },
+          {
+            "q": "Is there an Android version?",
+            "aHtml": "Not yet. Fingo is SwiftUI-native and we want to keep the animation and haptic quality at the standard it is. An Android port is on the table but not promised."
+          }
+        ]
+      },
+
+      "status": {
+        "titleHtml": "Everything <em>running.</em>",
+        "sub": "Current version, platform, and how quickly we get back.",
+        "rows": [
+          { "k": "Version", "v": "2.1.0" },
+          { "k": "Platform", "v": "iOS 26+" },
+          { "k": "Reply time", "v": "~ 18 hours" },
+          { "k": "Systems", "v": "All good", "ok": true }
+        ]
+      },
+
+      "cta": {
+        "titleHtml": "Still <em>stuck?</em>",
+        "sub": "Write to us directly.",
+        "label": "ivanlorenzana@outlook.com",
+        "href": "mailto:ivanlorenzana@outlook.com"
+      },
+
+      "sectionLabels": {
+        "contact": "01 — Contact",
+        "faq": "02 — Frequent questions",
+        "status": "03 — Status"
+      },
+
+      "privacyLabel": "Privacy",
+      "termsLabel": "Terms",
+      "backLabel": "Atelier Belli"
+    }
+  },
   "home": {
     "nav": {
       "home": "Home",

--- a/messages/es.json
+++ b/messages/es.json
@@ -185,6 +185,106 @@
       }
     }
   },
+  "support": {
+    "fingo": {
+      "name": "Fingo",
+      "crest": "F",
+      "navLabel": "Fingo · Soporte",
+      "footMeta": "Fingo — Mesa de soporte · 2025",
+
+      "hero": {
+        "eye": "Soporte · v2.1.0",
+        "titleHtml": "¿Cómo podemos <em>ayudar?</em>",
+        "lede": "Fingo es una pequeña app para decidir quién paga, quién empieza, quién escoge la música. Si algo no funciona como debería — escríbenos. Una persona real lee cada mensaje."
+      },
+
+      "contact": {
+        "titleHtml": "Estamos <em>aquí.</em>",
+        "sub": "Elige el canal que mejor te funcione. Todo llega al mismo escritorio.",
+        "cards": {
+          "email": {
+            "label": "Correo",
+            "valueHtml": "ivanlorenzana@outlook.com",
+            "hint": "Respondemos en 24h, normalmente antes.",
+            "href": "mailto:ivanlorenzana@outlook.com"
+          },
+          "bug": {
+            "label": "Reportar un error",
+            "valueHtml": "¿<em>Algo</em> se rompió?",
+            "hint": "Una nota breve y una captura ayudan mucho.",
+            "href": "mailto:ivanlorenzana@outlook.com?subject=Fingo%20bug%20report"
+          },
+          "feature": {
+            "label": "Sugerir función",
+            "valueHtml": "Imagina <em>mejor.</em>",
+            "hint": "Las leemos todas. Algunas se publican.",
+            "href": "mailto:ivanlorenzana@outlook.com?subject=Fingo%20wishlist"
+          },
+          "docs": {
+            "label": "Centro de ayuda",
+            "valueHtml": "Guías y consejos",
+            "hint": "Guías rápidas para los flujos más comunes.",
+            "href": "#"
+          }
+        }
+      },
+
+      "faq": {
+        "titleHtml": "Preguntas <em>frecuentes.</em>",
+        "sub": "Las que más nos llegan. Si la tuya no está, solo escribe.",
+        "items": [
+          {
+            "q": "¿Fingo comparte mis contactos o datos?",
+            "aHtml": "No. Fingo no envía tus contactos, elecciones, ni resultados a ningún lado. Todo vive en tu dispositivo; no hay cuenta ni servidor que filtre nada. Si borras la app, no queda rastro."
+          },
+          {
+            "q": "¿Por qué necesito activar los háptics?",
+            "aHtml": "Porque la mitad de la gracia de Fingo es el click. Puedes apagarlos en <em>Ajustes → Feedback</em>, pero te sugerimos probar al menos un giro con ellos."
+          },
+          {
+            "q": "¿Puedo usar Fingo sin conexión a internet?",
+            "aHtml": "Sí — completamente. Fingo es totalmente offline. Lo único que toca internet es cuando compartes un resultado como tarjeta por Mensajes o Mail."
+          },
+          {
+            "q": "¿Dónde restauro una compra?",
+            "aHtml": "Ajustes → Acerca de → Restaurar compras. Necesitas estar con el mismo Apple ID con el que compraste. Si aún así no funciona, <a href='mailto:ivanlorenzana@outlook.com'>escríbenos</a>."
+          },
+          {
+            "q": "¿Hay versión para Android?",
+            "aHtml": "Aún no. Fingo es nativo en SwiftUI y queremos mantener la calidad de animación y háptics al nivel que está. Un puerto a Android está sobre la mesa, pero no prometido."
+          }
+        ]
+      },
+
+      "status": {
+        "titleHtml": "Todo <em>funcionando.</em>",
+        "sub": "Versión actual, plataforma, y cuán rápido respondemos.",
+        "rows": [
+          { "k": "Versión", "v": "2.1.0" },
+          { "k": "Plataforma", "v": "iOS 26+" },
+          { "k": "Respuesta", "v": "~ 18 horas" },
+          { "k": "Sistemas", "v": "Todo bien", "ok": true }
+        ]
+      },
+
+      "cta": {
+        "titleHtml": "¿Sigues <em>atorado?</em>",
+        "sub": "Escríbenos directo.",
+        "label": "ivanlorenzana@outlook.com",
+        "href": "mailto:ivanlorenzana@outlook.com"
+      },
+
+      "sectionLabels": {
+        "contact": "01 — Contacto",
+        "faq": "02 — Preguntas frecuentes",
+        "status": "03 — Estado"
+      },
+
+      "privacyLabel": "Privacidad",
+      "termsLabel": "Términos",
+      "backLabel": "Atelier Belli"
+    }
+  },
   "home": {
     "nav": {
       "home": "Inicio",


### PR DESCRIPTION
## Summary

Implements Phase A + B of the Fingo half of `docs/opportunistic-improvements.md` §1. Replaces the legacy `CONTENT: Record<Lang, SupportContent>` pattern in `app/[locale]/fingo/support/page.tsx` with a `useTranslations("support.fingo")` + `useMemo` adapter that builds the same `SupportContent` shape consumed by `components/support-shell.tsx`. The shell stays untouched — the entire migration lives in the page-level adapter and the dictionary additions.

- `app/[locale]/fingo/support/page.tsx`: **201 → 65 lines**. Plain-text keys via `t()`; HTML-suffixed keys + array keys via `t.raw()`.
- `messages/{en,es}.json`: new top-level `support.fingo.*` namespace (51 keys). Convention from the plan: `Html`-suffix for values consumed via `dangerouslySetInnerHTML`; arrays for `faq.items` and `status.rows`; flat named contact cards (`email`, `bug`, `feature`, `docs`).

## Critical implementation detail (flag for the Savely follow-up PR)

`t()` runs the ICU message formatter, which treats `<em>` as a tag placeholder variable and throws `FORMATTING_ERROR`. The Fingo adapter therefore calls `t.raw()` on EVERY `*Html`-suffixed key — not just on the array values. The Savely migration must apply the same pattern.

## Gotchas honored
- `i18n-pattern-canonical` — no `isSpanish`, no `CONTENT[locale]`. `useParams().locale` stays only for `SupportShell`'s href construction (routing, not translation).
- `amplify-client-component-quirk` — provider untouched.
- `root-token-scoping` — zero CSS changes.

## Test plan
- [x] `pnpm exec tsc --noEmit` — green.
- [x] `pnpm build` — green; `/en/fingo/support` and `/es/fingo/support` still SSG.
- [ ] `pnpm lint` — will succeed once PR #22 (ESLint config) merges; pre-existing condition.
- [ ] Visual smoke `/en/fingo/support` and `/es/fingo/support` after merge — confirm hero/contact/FAQ/status/CTA all render with correct copy in both locales; FAQ accordion behavior unchanged; mailto links resolve to `ivanlorenzana@outlook.com`.

## Follow-ups
- Savely support page migration (mirror this PR's approach + the `t.raw()` for HTML detail above).
- Eventually: Destilería Lorenzana support page (when/if that lands; the `support` top-level namespace already has room).

🤖 Generated with [Claude Code](https://claude.com/claude-code)