### PR TITLE
Migrate Savely support page to next-intl

### DIFF
--- a/app/[locale]/savely/support/page.tsx
+++ b/app/[locale]/savely/support/page.tsx
@@ -1,203 +1,65 @@
 "use client"
 
+import { useMemo } from "react"
 import { useParams } from "next/navigation"
+import { useTranslations } from "next-intl"
 import SupportShell, { type SupportContent } from "@/components/support-shell"
 
-type Lang = "en" | "es"
-
-const CONTENT: Record<Lang, SupportContent> = {
-  en: {
-    name: "Savely",
-    crest: "S",
-    navLabel: "Savely · Support",
-    footMeta: "Savely — Support desk · 2025",
-
-    heroEye: "Support · v1.8",
-    heroTitle: "A calm <em>answer</em> to every question.",
-    heroLede:
-      "Savely is a quiet place for your money. If something looks off — a missing transaction, a chart that won't load, a bank that dropped — tell us. We'll sort it out, patiently.",
-
-    contactTitle: "Reach <em>us.</em>",
-    contactSub:
-      "Questions about your account, a bank connection, or something simpler. All roads lead to the same desk.",
-    contacts: [
-      {
-        kind: "email",
-        label: "Email",
-        value: "ivanlorenzana@outlook.com",
-        hint: "Mon–Fri · Replies within 24h.",
-        href: "mailto:ivanlorenzana@outlook.com",
-      },
-      {
-        kind: "bank",
-        label: "Bank connection",
-        value: "Can't <em>link</em> a bank?",
-        hint: "Most issues are fixed in under an hour.",
-        href: "mailto:ivanlorenzana@outlook.com?subject=Bank%20connection%20help",
-      },
-      {
-        kind: "security",
-        label: "Security concern",
-        value: "See something <em>odd?</em>",
-        hint: "Reported within 2 hours. 24/7.",
-        href: "mailto:ivanlorenzana@outlook.com",
-      },
-      {
-        kind: "docs",
-        label: "Help centre",
-        value: "Guides &amp; articles",
-        hint: "Setup, budgets, categories, exports.",
-        href: "#",
-      },
-    ],
-
-    faqTitle: "Common <em>questions.</em>",
-    faqSub: "If yours isn't here, write in. We answer each one by hand.",
-    faq: [
-      {
-        q: "Is my bank data safe with Savely?",
-        a: "Yes. Savely uses read-only bank connections via regulated aggregators. We never see or store your banking credentials. All data at rest is encrypted, and we never sell or share information with third parties.",
-      },
-      {
-        q: "Why can't I connect my bank?",
-        a: "Most often it's a temporary outage at the aggregator. Try again in ~30 minutes. If it persists, <a href='mailto:ivanlorenzana@outlook.com'>email us</a> with your bank name and country — we'll chase it down.",
-      },
-      {
-        q: "Can I export my data?",
-        a: "Yes. <em>Settings → Data → Export</em>. You'll get a CSV of all your transactions, categories, and budgets. Nothing is kept hostage.",
-      },
-      {
-        q: "How do budgets roll over at month end?",
-        a: "Unspent amounts either carry to next month or reset — your call. Set it per budget in <em>Budget → Options → Rollover</em>. The default is reset.",
-      },
-      {
-        q: "Does Savely work outside Europe?",
-        a: "Partial. EU, UK, and US banks work well. Canada and Australia are in public beta. Other regions — get in touch and we'll tell you honestly whether we can connect.",
-      },
-    ],
-
-    statusTitle: "Current <em>state.</em>",
-    statusSub: "Version, platform, response times, and system status.",
-    status: [
-      { k: "Version", v: "1.8.0" },
-      { k: "Platform", v: "iOS 16+" },
-      { k: "Reply time", v: "~ 14 hours" },
-      { k: "Systems", v: "All good", ok: true },
-    ],
-
-    ctaTitle: "Still <em>stuck?</em>",
-    ctaSub: "Write to us directly. A small team, real replies, patient answers.",
-    ctaLabel: "ivanlorenzana@outlook.com",
-    ctaHref: "mailto:ivanlorenzana@outlook.com",
-
-    sectionLabels: {
-      contact: "01 — Contact",
-      faq: "02 — Frequent questions",
-      status: "03 — Status",
-    },
-
-    privacyLabel: "Privacy",
-    termsLabel: "Terms",
-    backLabel: "Atelier Belli",
-  },
-  es: {
-    name: "Savely",
-    crest: "S",
-    navLabel: "Savely · Soporte",
-    footMeta: "Savely — Mesa de soporte · 2025",
-
-    heroEye: "Soporte · v1.8",
-    heroTitle: "Una respuesta <em>serena</em> a cada pregunta.",
-    heroLede:
-      "Savely es un lugar tranquilo para tu dinero. Si algo no cuadra — una transacción faltante, una gráfica que no carga, un banco que se desconectó — dinos. Lo resolvemos, con paciencia.",
-
-    contactTitle: "Háblanos.",
-    contactSub:
-      "Preguntas sobre tu cuenta, una conexión bancaria, o algo más simple. Todos los caminos llegan al mismo escritorio.",
-    contacts: [
-      {
-        kind: "email",
-        label: "Correo",
-        value: "ivanlorenzana@outlook.com",
-        hint: "Lun–Vie · Respondemos en 24h.",
-        href: "mailto:ivanlorenzana@outlook.com",
-      },
-      {
-        kind: "bank",
-        label: "Conexión bancaria",
-        value: "¿No puedes <em>vincular</em> un banco?",
-        hint: "La mayoría se resuelve en menos de una hora.",
-        href: "mailto:ivanlorenzana@outlook.com?subject=Bank%20connection%20help",
-      },
-      {
-        kind: "security",
-        label: "Asunto de seguridad",
-        value: "¿Viste algo <em>extraño?</em>",
-        hint: "Reportado en menos de 2 horas. 24/7.",
-        href: "mailto:ivanlorenzana@outlook.com",
-      },
-      {
-        kind: "docs",
-        label: "Centro de ayuda",
-        value: "Guías y artículos",
-        hint: "Configuración, presupuestos, categorías, exportaciones.",
-        href: "#",
-      },
-    ],
-
-    faqTitle: "Preguntas <em>comunes.</em>",
-    faqSub: "Si la tuya no está, escríbenos. Respondemos cada una a mano.",
-    faq: [
-      {
-        q: "¿Están seguros mis datos bancarios con Savely?",
-        a: "Sí. Savely usa conexiones de solo lectura vía agregadores regulados. Nunca vemos ni almacenamos tus credenciales bancarias. Todos los datos en reposo están cifrados, y nunca vendemos ni compartimos información con terceros.",
-      },
-      {
-        q: "¿Por qué no puedo conectar mi banco?",
-        a: "La mayoría de las veces es una caída temporal del agregador. Intenta de nuevo en ~30 minutos. Si persiste, <a href='mailto:ivanlorenzana@outlook.com'>escríbenos</a> con el nombre de tu banco y país — lo perseguimos.",
-      },
-      {
-        q: "¿Puedo exportar mis datos?",
-        a: "Sí. <em>Ajustes → Datos → Exportar</em>. Obtendrás un CSV con todas tus transacciones, categorías y presupuestos. Nada queda de rehén.",
-      },
-      {
-        q: "¿Cómo funcionan los presupuestos al fin de mes?",
-        a: "Los montos sin usar pueden trasladarse al siguiente mes o resetearse — tú decides. Configúralo por presupuesto en <em>Presupuesto → Opciones → Rollover</em>. El default es resetear.",
-      },
-      {
-        q: "¿Funciona Savely fuera de Europa?",
-        a: "Parcialmente. Bancos de la UE, Reino Unido y EE.UU. funcionan bien. Canadá y Australia están en beta. Otras regiones — escríbenos y te decimos honestamente si podemos conectar.",
-      },
-    ],
-
-    statusTitle: "Estado <em>actual.</em>",
-    statusSub: "Versión, plataforma, tiempos de respuesta y estado de sistemas.",
-    status: [
-      { k: "Versión", v: "1.8.0" },
-      { k: "Plataforma", v: "iOS 16+" },
-      { k: "Respuesta", v: "~ 14 horas" },
-      { k: "Sistemas", v: "Todo bien", ok: true },
-    ],
-
-    ctaTitle: "¿Sigues <em>atorado?</em>",
-    ctaSub: "Escríbenos directo. Un equipo pequeño, respuestas reales, con paciencia.",
-    ctaLabel: "ivanlorenzana@outlook.com",
-    ctaHref: "mailto:ivanlorenzana@outlook.com",
-
-    sectionLabels: {
-      contact: "01 — Contacto",
-      faq: "02 — Preguntas frecuentes",
-      status: "03 — Estado",
-    },
-
-    privacyLabel: "Privacidad",
-    termsLabel: "Términos",
-    backLabel: "Atelier Belli",
-  },
-}
+const CONTACT_KINDS = ["email", "bank", "security", "docs"] as const
 
 export default function SavelySupportPage() {
+  const t = useTranslations("support.savely")
   const params = useParams()
-  const locale = (((params?.locale as string) || "en") === "es" ? "es" : "en") as Lang
-  return <SupportShell appKey="savely" locale={locale} content={CONTENT[locale]} />
+  const locale = (params?.locale as string) === "es" ? "es" : "en"
+
+  const content = useMemo<SupportContent>(
+    () => ({
+      name: t("name"),
+      crest: t("crest"),
+      navLabel: t("navLabel"),
+      footMeta: t("footMeta"),
+
+      heroEye: t("hero.eye"),
+      heroTitle: t.raw("hero.titleHtml") as string,
+      heroLede: t("hero.lede"),
+
+      contactTitle: t.raw("contact.titleHtml") as string,
+      contactSub: t("contact.sub"),
+      contacts: CONTACT_KINDS.map((kind) => ({
+        kind,
+        label: t(`contact.cards.${kind}.label`),
+        value: t.raw(`contact.cards.${kind}.valueHtml`) as string,
+        hint: t(`contact.cards.${kind}.hint`),
+        href: t(`contact.cards.${kind}.href`),
+      })),
+
+      faqTitle: t.raw("faq.titleHtml") as string,
+      faqSub: t("faq.sub"),
+      faq: (t.raw("faq.items") as Array<{ q: string; aHtml: string }>).map(
+        ({ q, aHtml }) => ({ q, a: aHtml }),
+      ),
+
+      statusTitle: t.raw("status.titleHtml") as string,
+      statusSub: t("status.sub"),
+      status: t.raw("status.rows") as Array<{ k: string; v: string; ok?: boolean }>,
+
+      ctaTitle: t.raw("cta.titleHtml") as string,
+      ctaSub: t("cta.sub"),
+      ctaLabel: t("cta.label"),
+      ctaHref: t("cta.href"),
+
+      sectionLabels: {
+        contact: t("sectionLabels.contact"),
+        faq: t("sectionLabels.faq"),
+        status: t("sectionLabels.status"),
+      },
+
+      privacyLabel: t("privacyLabel"),
+      termsLabel: t("termsLabel"),
+      backLabel: t("backLabel"),
+    }),
+    [t],
+  )
+
+  return <SupportShell appKey="savely" locale={locale} content={content} />
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -186,6 +186,104 @@
     }
   },
   "support": {
+    "savely": {
+      "name": "Savely",
+      "crest": "S",
+      "navLabel": "Savely · Support",
+      "footMeta": "Savely — Support desk · 2025",
+
+      "hero": {
+        "eye": "Support · v1.8",
+        "titleHtml": "A calm <em>answer</em> to every question.",
+        "lede": "Savely is a quiet place for your money. If something looks off — a missing transaction, a chart that won't load, a bank that dropped — tell us. We'll sort it out, patiently."
+      },
+
+      "contact": {
+        "titleHtml": "Reach <em>us.</em>",
+        "sub": "Questions about your account, a bank connection, or something simpler. All roads lead to the same desk.",
+        "cards": {
+          "email": {
+            "label": "Email",
+            "valueHtml": "ivanlorenzana@outlook.com",
+            "hint": "Mon–Fri · Replies within 24h.",
+            "href": "mailto:ivanlorenzana@outlook.com"
+          },
+          "bank": {
+            "label": "Bank connection",
+            "valueHtml": "Can't <em>link</em> a bank?",
+            "hint": "Most issues are fixed in under an hour.",
+            "href": "mailto:ivanlorenzana@outlook.com?subject=Bank%20connection%20help"
+          },
+          "security": {
+            "label": "Security concern",
+            "valueHtml": "See something <em>odd?</em>",
+            "hint": "Reported within 2 hours. 24/7.",
+            "href": "mailto:ivanlorenzana@outlook.com"
+          },
+          "docs": {
+            "label": "Help centre",
+            "valueHtml": "Guides &amp; articles",
+            "hint": "Setup, budgets, categories, exports.",
+            "href": "#"
+          }
+        }
+      },
+
+      "faq": {
+        "titleHtml": "Common <em>questions.</em>",
+        "sub": "If yours isn't here, write in. We answer each one by hand.",
+        "items": [
+          {
+            "q": "Is my bank data safe with Savely?",
+            "aHtml": "Yes. Savely uses read-only bank connections via regulated aggregators. We never see or store your banking credentials. All data at rest is encrypted, and we never sell or share information with third parties."
+          },
+          {
+            "q": "Why can't I connect my bank?",
+            "aHtml": "Most often it's a temporary outage at the aggregator. Try again in ~30 minutes. If it persists, <a href='mailto:ivanlorenzana@outlook.com'>email us</a> with your bank name and country — we'll chase it down."
+          },
+          {
+            "q": "Can I export my data?",
+            "aHtml": "Yes. <em>Settings → Data → Export</em>. You'll get a CSV of all your transactions, categories, and budgets. Nothing is kept hostage."
+          },
+          {
+            "q": "How do budgets roll over at month end?",
+            "aHtml": "Unspent amounts either carry to next month or reset — your call. Set it per budget in <em>Budget → Options → Rollover</em>. The default is reset."
+          },
+          {
+            "q": "Does Savely work outside Europe?",
+            "aHtml": "Partial. EU, UK, and US banks work well. Canada and Australia are in public beta. Other regions — get in touch and we'll tell you honestly whether we can connect."
+          }
+        ]
+      },
+
+      "status": {
+        "titleHtml": "Current <em>state.</em>",
+        "sub": "Version, platform, response times, and system status.",
+        "rows": [
+          { "k": "Version", "v": "1.8.0" },
+          { "k": "Platform", "v": "iOS 16+" },
+          { "k": "Reply time", "v": "~ 14 hours" },
+          { "k": "Systems", "v": "All good", "ok": true }
+        ]
+      },
+
+      "cta": {
+        "titleHtml": "Still <em>stuck?</em>",
+        "sub": "Write to us directly. A small team, real replies, patient answers.",
+        "label": "ivanlorenzana@outlook.com",
+        "href": "mailto:ivanlorenzana@outlook.com"
+      },
+
+      "sectionLabels": {
+        "contact": "01 — Contact",
+        "faq": "02 — Frequent questions",
+        "status": "03 — Status"
+      },
+
+      "privacyLabel": "Privacy",
+      "termsLabel": "Terms",
+      "backLabel": "Atelier Belli"
+    },
     "fingo": {
       "name": "Fingo",
       "crest": "F",

--- a/messages/es.json
+++ b/messages/es.json
@@ -186,6 +186,104 @@
     }
   },
   "support": {
+    "savely": {
+      "name": "Savely",
+      "crest": "S",
+      "navLabel": "Savely · Soporte",
+      "footMeta": "Savely — Mesa de soporte · 2025",
+
+      "hero": {
+        "eye": "Soporte · v1.8",
+        "titleHtml": "Una respuesta <em>serena</em> a cada pregunta.",
+        "lede": "Savely es un lugar tranquilo para tu dinero. Si algo no cuadra — una transacción faltante, una gráfica que no carga, un banco que se desconectó — dinos. Lo resolvemos, con paciencia."
+      },
+
+      "contact": {
+        "titleHtml": "Háblanos.",
+        "sub": "Preguntas sobre tu cuenta, una conexión bancaria, o algo más simple. Todos los caminos llegan al mismo escritorio.",
+        "cards": {
+          "email": {
+            "label": "Correo",
+            "valueHtml": "ivanlorenzana@outlook.com",
+            "hint": "Lun–Vie · Respondemos en 24h.",
+            "href": "mailto:ivanlorenzana@outlook.com"
+          },
+          "bank": {
+            "label": "Conexión bancaria",
+            "valueHtml": "¿No puedes <em>vincular</em> un banco?",
+            "hint": "La mayoría se resuelve en menos de una hora.",
+            "href": "mailto:ivanlorenzana@outlook.com?subject=Bank%20connection%20help"
+          },
+          "security": {
+            "label": "Asunto de seguridad",
+            "valueHtml": "¿Viste algo <em>extraño?</em>",
+            "hint": "Reportado en menos de 2 horas. 24/7.",
+            "href": "mailto:ivanlorenzana@outlook.com"
+          },
+          "docs": {
+            "label": "Centro de ayuda",
+            "valueHtml": "Guías y artículos",
+            "hint": "Configuración, presupuestos, categorías, exportaciones.",
+            "href": "#"
+          }
+        }
+      },
+
+      "faq": {
+        "titleHtml": "Preguntas <em>comunes.</em>",
+        "sub": "Si la tuya no está, escríbenos. Respondemos cada una a mano.",
+        "items": [
+          {
+            "q": "¿Están seguros mis datos bancarios con Savely?",
+            "aHtml": "Sí. Savely usa conexiones de solo lectura vía agregadores regulados. Nunca vemos ni almacenamos tus credenciales bancarias. Todos los datos en reposo están cifrados, y nunca vendemos ni compartimos información con terceros."
+          },
+          {
+            "q": "¿Por qué no puedo conectar mi banco?",
+            "aHtml": "La mayoría de las veces es una caída temporal del agregador. Intenta de nuevo en ~30 minutos. Si persiste, <a href='mailto:ivanlorenzana@outlook.com'>escríbenos</a> con el nombre de tu banco y país — lo perseguimos."
+          },
+          {
+            "q": "¿Puedo exportar mis datos?",
+            "aHtml": "Sí. <em>Ajustes → Datos → Exportar</em>. Obtendrás un CSV con todas tus transacciones, categorías y presupuestos. Nada queda de rehén."
+          },
+          {
+            "q": "¿Cómo funcionan los presupuestos al fin de mes?",
+            "aHtml": "Los montos sin usar pueden trasladarse al siguiente mes o resetearse — tú decides. Configúralo por presupuesto en <em>Presupuesto → Opciones → Rollover</em>. El default es resetear."
+          },
+          {
+            "q": "¿Funciona Savely fuera de Europa?",
+            "aHtml": "Parcialmente. Bancos de la UE, Reino Unido y EE.UU. funcionan bien. Canadá y Australia están en beta. Otras regiones — escríbenos y te decimos honestamente si podemos conectar."
+          }
+        ]
+      },
+
+      "status": {
+        "titleHtml": "Estado <em>actual.</em>",
+        "sub": "Versión, plataforma, tiempos de respuesta y estado de sistemas.",
+        "rows": [
+          { "k": "Versión", "v": "1.8.0" },
+          { "k": "Plataforma", "v": "iOS 16+" },
+          { "k": "Respuesta", "v": "~ 14 horas" },
+          { "k": "Sistemas", "v": "Todo bien", "ok": true }
+        ]
+      },
+
+      "cta": {
+        "titleHtml": "¿Sigues <em>atorado?</em>",
+        "sub": "Escríbenos directo. Un equipo pequeño, respuestas reales, con paciencia.",
+        "label": "ivanlorenzana@outlook.com",
+        "href": "mailto:ivanlorenzana@outlook.com"
+      },
+
+      "sectionLabels": {
+        "contact": "01 — Contacto",
+        "faq": "02 — Preguntas frecuentes",
+        "status": "03 — Estado"
+      },
+
+      "privacyLabel": "Privacidad",
+      "termsLabel": "Términos",
+      "backLabel": "Atelier Belli"
+    },
     "fingo": {
       "name": "Fingo",
       "crest": "F",


### PR DESCRIPTION
## Summary

Mirror of the Fingo migration (PR #23) for the Savely support page. Closes the support-page migration plan in `docs/opportunistic-improvements.md` §1 — the `CONTENT[locale]` pattern is now extinct across the codebase.

- `app/[locale]/savely/support/page.tsx`: **203 → 65 lines**. Same `useTranslations + useMemo` adapter pattern as Fingo. Plain-text keys via `t()`; `Html`-suffixed keys + array keys via `t.raw()` — applying the lesson from PR #23 from the start.
- `messages/{en,es}.json`: new `support.savely.*` namespace as sibling to `support.fingo`. 54 keys.
- `components/support-shell.tsx` and `app/[locale]/fingo/support/page.tsx` NOT touched.

## Divergence from Fingo

Contact kinds are `["email", "bank", "security", "docs"]` (Fingo: `["email", "bug", "feature", "docs"]`). The shell's `ContactKind` union accepts whichever kinds the page produces; no shell changes needed.

## Gotchas honored
- `i18n-pattern-canonical` — zero `isSpanish`, zero `Record<Lang, ...>`. `useParams().locale` only for `SupportShell` href construction.
- `amplify-client-component-quirk` — provider untouched.
- `root-token-scoping` — zero CSS changes.

## Test plan
- [x] `pnpm exec tsc --noEmit` — green.
- [x] `pnpm build` — green; `/en/savely/support` and `/es/savely/support` still SSG.
- [x] `pnpm lint` — green (ESLint configured per #22).
- [ ] Visual smoke `/en/savely/support` and `/es/savely/support` after merge — confirm hero/contact/FAQ/status/CTA all render with correct copy in both locales; FAQ accordion behavior unchanged; mailto links resolve to `ivanlorenzana@outlook.com`.

## Aftermath

Both `support` pages now live in next-intl. The `CONTENT[locale]` pattern is gone from the source tree. `docs/opportunistic-improvements.md` §1 can be marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)