### PR TITLE
Case-study deep links + title simplification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,9 @@ in `app/[locale]/page.tsx` — there are NO per-case route files. To add a case:
 5. Add `cases.<key>` to **both** `messages/en.json` and `messages/es.json`
    (titleIt, descRich with `<it>` tags, metaStatus, actionPrimary, tag,
    metaPlatform when not iOS).
+6. Add the new key to `CASE_KEYS` (the deep-link allowlist, right below the
+   `CaseKey` union in `page.tsx`), and bump the six-case count assertion in
+   `tests/e2e/smoke.spec.ts` (the comment on Test 5).
 
 **Previews:** project screenshots live in `public/cases/` (fingo/savely
 predate the folder and keep their root-level `public/*-hero.*` files).

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -10,6 +10,7 @@ type Lang = "en" | "es"
 type Theme = "light" | "dark"
 
 type CaseKey = "fingo" | "savely" | "mezcal" | "blip" | "briefmark" | "pass"
+const CASE_KEYS: readonly CaseKey[] = ["fingo", "savely", "mezcal", "blip", "briefmark", "pass"]
 
 type CaseAction = {
   label: string
@@ -94,6 +95,13 @@ export default function PortfolioPage() {
     }
     setTheme(initial)
     setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    const param = new URLSearchParams(window.location.search).get("case")
+    if (param && (CASE_KEYS as readonly string[]).includes(param)) {
+      setOpenCaseKey(param as CaseKey)
+    }
   }, [])
 
   useEffect(() => {
@@ -296,10 +304,16 @@ export default function PortfolioPage() {
   const openCase = useCallback((key: CaseKey, trigger?: HTMLElement) => {
     lastFocusRef.current = trigger ?? (document.activeElement as HTMLElement | null)
     setOpenCaseKey(key)
+    const url = new URL(window.location.href)
+    url.searchParams.set("case", key)
+    window.history.replaceState(null, "", url)
   }, [])
 
   const closeCase = useCallback(() => {
     setOpenCaseKey(null)
+    const url = new URL(window.location.href)
+    url.searchParams.delete("case")
+    window.history.replaceState(null, "", url)
   }, [])
 
   useEffect(() => {

--- a/messages/en.json
+++ b/messages/en.json
@@ -13,7 +13,7 @@
   },
   "layout": {
     "skipToContent": "Skip to main content",
-    "metaTitle": "Atelier Belli — Digital craft, Franco-Italian.",
+    "metaTitle": "Atelier Belli",
     "metaDescription": "Atelier Belli is the digital atelier of Ivan Lorenzana — full-stack developer crafting clean iOS apps and the web around them. Fingo, Savely, Mi Mezcal and more.",
     "ogAlt": "Atelier Belli — portfolio of Ivan Lorenzana"
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -13,7 +13,7 @@
   },
   "layout": {
     "skipToContent": "Ir al contenido principal",
-    "metaTitle": "Atelier Belli — Artesanía digital, franco-italiana.",
+    "metaTitle": "Atelier Belli",
     "metaDescription": "Atelier Belli es el atelier digital de Ivan Lorenzana — desarrollador full-stack que crea aplicaciones iOS limpias y la web que las rodea. Fingo, Savely, Mi Mezcal y más.",
     "ogAlt": "Atelier Belli — portafolio de Ivan Lorenzana"
   },

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,7 +22,7 @@ Repo-wide rules every executor must honor (from CLAUDE.md):
 | 003  | Verification baseline (typecheck, i18n parity, Playwright) | P1 | M | 001 (soft) | DONE — `pnpm verify` + 6-test Playwright suite, executed+reviewed 2026-06-10, integrated in `chore/next-upgrade-and-test-baseline` |
 | 004  | Orphaned vitrine CSS + savely WebP + cookie hygiene | P2 | S | — | DONE — executed+reviewed 2026-06-10 (195 CSS lines gone, savely 251KB→34.5KB webp, SameSite=Lax, placeholders dropped); integrated in `chore/css-cleanup-and-seo` |
 | 005  | SEO & shareability (metadata, hreflang, OG, sitemap, robots) | P2 | M | 003 (recommended) | DONE — executed+reviewed 2026-06-10 (per-locale generateMetadata, hreflang, OG card 1200×630, sitemap 12 URLs, robots); integrated in `chore/css-cleanup-and-seo`; Amplify preview gate pending at release PR |
-| 006  | Case-study deep links (`?case=` URL state)         | P3 | M | 003 (hard) | TODO |
+| 006  | Case-study deep links (`?case=` URL state)         | P3 | M | 003 (hard) | DONE — executed+reviewed 2026-06-10, 9/9 E2E, `/[locale]` stays SSG; integrated in `feat/case-deep-links` (+ owner-requested title simplification) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale)
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -74,8 +74,53 @@ test("theme toggle flips data-theme and persists to localStorage", async ({
 });
 
 // ── Test 5: /es/ shows all six cases ─────────────────────────────────────────
-// Bump this count when a 7th case ships.
+// Bump this count when a 7th case ships (also update CASE_KEYS in page.tsx).
 test("/es/ shows all six cases", async ({ page }) => {
   await page.goto("/es/");
   await expect(page.locator("button.ab-index-row")).toHaveCount(6);
+});
+
+// ── Test 6: deep link opens the right case ────────────────────────────────────
+test("?case=blip deep link opens the BLIP modal; Escape clears the param", async ({
+  page,
+}) => {
+  await page.goto("/en/?case=blip");
+
+  // Modal should be visible and contain the case title
+  const modal = page.locator(".ab-case-modal.open");
+  await expect(modal).toBeVisible();
+  await expect(modal).toContainText("BLIP");
+
+  // Escape closes the modal and removes the param
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".ab-case-modal.open")).toHaveCount(0);
+  expect(page.url()).not.toContain("case=");
+});
+
+// ── Test 7: opening a case writes the ?case= param ───────────────────────────
+test("clicking a case row adds ?case=fingo to the URL", async ({ page }) => {
+  await page.goto("/en/");
+
+  const firstRow = page.locator("button.ab-index-row").first();
+  await firstRow.click();
+
+  // URL should now contain ?case=fingo (fingo is the first case)
+  await expect(page).toHaveURL(/[?&]case=fingo/);
+
+  // Escape removes the param
+  await page.keyboard.press("Escape");
+  await expect(async () => {
+    expect(page.url()).not.toContain("case=");
+  }).toPass();
+});
+
+// ── Test 8: invalid ?case= key is silently ignored ───────────────────────────
+test("?case=notreal does not open any modal", async ({ page }) => {
+  await page.goto("/en/?case=notreal");
+
+  // No open modal
+  await expect(page.locator(".ab-case-modal.open")).toHaveCount(0);
+
+  // Page still renders correctly
+  await expect(page.locator("h1")).toBeVisible();
 });


### PR DESCRIPTION
Executes plan 006 (the last one) + an owner-requested copy change.

## Plan 006 — shareable case deep links (`19823de`)
- `/{locale}/?case=<key>` opens the matching case modal on a fresh load; opening/closing modals syncs the param via `history.replaceState` (URL always copyable, Back/Forward unaffected).
- Invalid keys ignored silently. Deliberately **no** `useSearchParams` — `window.location` in a mount effect keeps `/[locale]` fully SSG (verified: still `●` in the build).
- 3 new E2E tests (deep link opens BLIP, click writes `?case=fingo`, invalid key no-ops) → suite is now **9 tests**; the pre-existing focus-restore test passes unchanged.
- CLAUDE.md §1 "add a case" checklist gained step 6 (extend `CASE_KEYS` + bump the E2E count).

## Title simplification (`<title>` / og:title) (`e9…`)
- `layout.metaTitle` EN+ES → just **"Atelier Belli"** (was "Atelier Belli — Digital craft, Franco-Italian." / "— Artesanía digital, franco-italiana."). Descriptions unchanged. 1-line diff per dictionary.

## Verified
`pnpm verify` ✔ (263 keys) · `pnpm test:e2e` **9/9** ✔ · production build in isolated copy ✔ 17/17, `/[locale]` static (main-tree `.next` untouched — a dev server was live on :3000).

With this merged, **all six plans from the 2026-06-10 audit are DONE** (see `plans/README.md`). Remaining release-time gate: Amplify deploy preview eyeball (plans 002+005 touched the sensitive region).